### PR TITLE
Add UIControl.State conformance

### DIFF
--- a/Sources/CustomDump/Conformances/UIKit.swift
+++ b/Sources/CustomDump/Conformances/UIKit.swift
@@ -60,5 +60,30 @@
         }
       }
     }
+    
+    @available(iOS 2, macCatalyst 13, tvOS 9, *)
+    @available(watchOS, unavailable)
+    extension UIControl.State: CustomDumpStringConvertible {
+      public var customDumpDescription: String {
+        switch self {
+        case .normal:
+          return "UIControl.State.normal"
+        case .highlighted:
+          return "UIControl.State.highlighted"
+        case .disabled:
+          return "UIControl.State.disabled"
+        case .selected:
+          return "UIControl.State.selected"
+        case .focused:
+          return "UIControl.State.focused"
+        case .application:
+          return "UIControl.State.application"
+        case .reserved:
+          return "UIControl.State.reserved"
+        default:
+          return "UIControl.State.(default, rawValue: \(self.rawValue))"
+        }
+      }
+    }
   #endif
 #endif

--- a/Tests/CustomDumpTests/Conformances/UIKitTests.swift
+++ b/Tests/CustomDumpTests/Conformances/UIKitTests.swift
@@ -1,0 +1,16 @@
+#if canImport(UIKit)
+  import CustomDump
+  import XCTest
+  import UIKit
+
+  final class UIKitTests: XCTestCase {
+    func testUIControlState() {
+      var output: String = ""
+      customDump(UIControl.State.selected, to: &output)
+      XCTAssertEqual(
+        output,
+        "UIControl.State.selected"
+      )
+    }
+  }
+#endif


### PR DESCRIPTION
Because it is widely used.
And, I added a sample tests for UIKit. 
I think that this is important for added enumeration case in the future. (like a unknown default)