### PR TITLE
Add dump String.StringInterpolation

### DIFF
--- a/Sources/CustomDump/StringInterpolation.swift
+++ b/Sources/CustomDump/StringInterpolation.swift
@@ -1,0 +1,7 @@
+extension String.StringInterpolation {
+  public mutating func appendInterpolation<T>(dump value: T) {
+    var target = ""
+    _ = customDump(value, to: &target, name: nil, indent: 0, maxDepth: .max)
+    appendLiteral(target)
+  }
+}


### PR DESCRIPTION
Adds string interpolation for dump function

```swift
let object = Object()
print("sample \(dump: object)")
```