### PR TITLE
Add Decimal conformance

### DIFF
--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -54,6 +54,12 @@ extension Date: CustomDumpStringConvertible {
   }()
 }
 
+extension Decimal: CustomDumpStringConvertible {
+  public var customDumpDescription: String {
+    self.description
+  }
+}
+
 extension Locale: CustomDumpStringConvertible {
   public var customDumpDescription: String {
     "Locale(\(self.identifier))"

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -777,6 +777,18 @@ final class DumpTests: XCTestCase {
 
     dump = ""
     customDump(
+      Decimal(string: "1.23"),
+      to: &dump
+    )
+    XCTAssertNoDifference(
+      dump,
+      """
+      1.23
+      """
+    )
+
+    dump = ""
+    customDump(
       [1, 2, 3] as NSArray,
       to: &dump
     )


### PR DESCRIPTION
```swift
customDump(NSDecimalNumber(string: "1.23"))
customDump(Decimal(string: "1.23"))
```

Before:

```
1.23
NSDecimal(
  _mantissa: (
    123,
    0,
    0,
    0,
    0,
    0,
    0,
    0
  )
)
```

After:

```
1.23
1.23
```

---

Note: Swift.dump

```swift
dump(NSDecimalNumber(string: "1.23"))
dump(Decimal(string: "1.23"))
```

```
- 1.23 #0
  - super: NSNumber
    - super: NSValue
      - super: NSObject
▿ Optional(1.23)
  ▿ some: 1.23
    ▿ _mantissa: (8 elements)
      - .0: 123
      - .1: 0
      - .2: 0
      - .3: 0
      - .4: 0
      - .5: 0
      - .6: 0
      - .7: 0
```