### PR TITLE
Add Windows testing support on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run tests
         run: make test-linux
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Swift & Run tests
+        uses: MaxDesiatov/swift-windows-action@v1
+        with:
+          shell-action: swift test && swift build -c release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - name: Install Swift & Run tests

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -1119,12 +1119,21 @@ final class DumpTests: XCTestCase {
       NSURL(fileURLWithPath: "/tmp"),
       to: &dump
     )
-    XCTAssertNoDifference(
-      dump,
-      """
-      URL(file:///tmp/)
-      """
-    )
+    #if os(Windows)
+      XCTAssertNoDifference(
+        dump,
+        """
+        URL(file:///tmp)
+        """
+      )
+    #else
+      XCTAssertNoDifference(
+        dump,
+        """
+        URL(file:///tmp/)
+        """
+      )
+    #endif
 
     dump = ""
     customDump(


### PR DESCRIPTION
I recently added tests for the Windows platform on a tool using this library and it failed while running this libraries manifest file. Thus I believe it's probably a good idea to test for Windows support right within this repo.

The exact command that hung up for 6 hours was:
```
C:\Users\runneradmin\AppData\Local\Temp\TemporaryDirectory.vFcVbW\swift-custom-dump-manifest.exe -handle 674
```

Here's the GitHub Actions run with the full test output:
https://github.com/Flinesoft/AnyLint/runs/3576556438?check_suite_focus=true