### PR TITLE
Improve dumping of Errors bridged to NSError

### DIFF
--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -92,7 +92,11 @@ extension NSDate: CustomDumpRepresentable {
 
 extension NSError: CustomDumpReflectable {
   public var customDumpMirror: Mirror {
-    .init(
+    let swiftError = self as Error
+    guard type(of: swiftError) is NSError.Type else {
+      return Mirror(reflecting: swiftError)
+    }
+    return Mirror(
       self,
       children: [
         "domain": self.domain,


### PR DESCRIPTION
When dumping a Swift Error bridged to NSError, we'd only show the error
domain and error code generated by the Swift runtime. We can get much
better output (e.g., enum/case names, associated values, etc.) if we
unwrap the Swift Error and dump it directly.