### PR TITLE
Don't compile symbols for mac catalyst that are not yet available out of beta

### DIFF
--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -5,7 +5,7 @@ import Foundation
 #endif
 
 // NB: Xcode 13 does not include macOS 12 SDK
-#if compiler(>=5.5) && !os(macOS)
+#if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst)
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension AttributedString: CustomDumpRepresentable {
     public var customDumpValue: Any {

--- a/Sources/CustomDump/Conformances/UserNotifications.swift
+++ b/Sources/CustomDump/Conformances/UserNotifications.swift
@@ -106,7 +106,7 @@
   }
 
   // NB: Xcode 13 does not include macOS 12 SDK
-  #if compiler(>=5.5) && !os(macOS)
+  #if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst)
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
     extension UNNotificationInterruptionLevel: CustomDumpStringConvertible {
       public var customDumpDescription: String {


### PR DESCRIPTION
When compiling this library for mac catalyst, a couple symbols are still not available in that platform/environment combination, and compiler errors show up as a result. This PR will opt to avoid compiling those symbols when in mac catalyst mode in Xcode 13.
