### PR TITLE
Don't compile symbols for Linux that are not yet available

### DIFF
--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -5,7 +5,8 @@ import Foundation
 #endif
 
 // NB: Xcode 13 does not include macOS 12 SDK
-#if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst)
+// NB: Swift 5.5 does not include AttributedString in Linux (yet)
+#if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst) && !os(Linux)
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension AttributedString: CustomDumpRepresentable {
     public var customDumpValue: Any {

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -724,7 +724,7 @@ final class DumpTests: XCTestCase {
   func testFoundation() {
     var dump = ""
 
-    #if compiler(>=5.5) && !os(macOS)
+    #if compiler(>=5.5) && !os(macOS) && !os(Linux)
       if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
         dump = ""
         customDump(


### PR DESCRIPTION
Basically the same as #20 but for Linux this time. This PR fixes Swift 5.5 compilation on Linux.

Backstory: Swift 5.5 images don't come bundled with a version of Foundation containing `AttributedString` yet. Whilst the changes are [in the upstream branch](https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/Foundation/AttributedString/AttributedString.swift), a release hasn't been made yet — I believe because macOS 12 is not out yet and Apple wants parity with "Apple Foundation".