### PR TITLE
Check catalyst in AttributedString tests.

### DIFF
--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -718,7 +718,7 @@ final class DumpTests: XCTestCase {
   func testFoundation() {
     var dump = ""
 
-    #if compiler(>=5.5) && !os(macOS) && !os(Linux)
+    #if compiler(>=5.5) && !os(macOS) && !targetEnvironment(macCatalyst) && !os(Linux)
       if #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) {
         dump = ""
         customDump(


### PR DESCRIPTION
Makes the test's `#if` logic match that of the logic in Foundation.swift.