### PR TITLE
UNNotificationPresentationOptions [.banner, .list] workaround

### DIFF
--- a/Sources/CustomDump/Conformances/UserNotifications.swift
+++ b/Sources/CustomDump/Conformances/UserNotifications.swift
@@ -173,6 +173,9 @@
       )
     }
       
+    // NB: Workaround for Xcode 13.2's new, experimental build system.
+    //
+    //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
     private func appendBannerList(_ allCases: inout [UNNotificationPresentationOptions]) {
       if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
         allCases.append(contentsOf: [.banner, .list])

--- a/Sources/CustomDump/Conformances/UserNotifications.swift
+++ b/Sources/CustomDump/Conformances/UserNotifications.swift
@@ -154,9 +154,7 @@
         .alert,
         .badge,
       ]
-      if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
-        allCases.append(contentsOf: [.banner, .list])
-      }
+      appendBannerList(&allCases)
       allCases.append(.sound)
       for option in allCases {
         if options.contains(option) {
@@ -173,6 +171,12 @@
         unlabeledChildren: children,
         displayStyle: .set
       )
+    }
+      
+    private func appendBannerList(_ allCases: inout [UNNotificationPresentationOptions]) {
+      if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
+        allCases.append(contentsOf: [.banner, .list])
+      }
     }
   }
 


### PR DESCRIPTION
Xcode 13.2 introduced a new build system that seems to have troubles with availability checks in getters.

https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2-release-notes

Seeing ~30% speedup with this setting, it's kind of a bummer it can't be turned on with projects using TCA 😞 

Moving the check out of the getter fixes the compile issue.

This solution may not be the PointFree way 😸 