### PR TITLE
Run 13.2 CI on experimental build system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - '13.2.1'
         include:
           - xcode: '13.2.1'
-          - experimental-build-system: true
+            experimental-build-system: true
     steps:
       - uses: actions/checkout@v2
       - name: Enable Experimental Build System

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,19 @@ jobs:
     runs-on: macOS-11.0
     strategy:
       matrix:
+        experimental-build-system: [false]
         xcode:
           - '13.0'
           - '13.1'
           - '13.2.1'
+        include:
+          - xcode: '13.2.1'
+          - experimental-build-system: true
     steps:
       - uses: actions/checkout@v2
+      - name: Enable Experimental Build System
+        if: ${{ matrix.experimental-build-system }}
+        run: defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Print Swift version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
             experimental-build-system: true
     steps:
       - uses: actions/checkout@v2
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Enable Experimental Build System
         if: ${{ matrix.experimental-build-system }}
         run: defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
-      - name: Select Xcode ${{ matrix.xcode }}
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Print Swift version
         run: swift --version
       - name: Run tests (Swift)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: macOS-11.0
     strategy:
       matrix:
-        experimental-build-system: [false]
         xcode:
           - '13.0'
           - '13.1'
           - '13.2.1'
+        experimental-build-system: [false]
         include:
           - xcode: '13.2.1'
             experimental-build-system: true

--- a/Sources/CustomDump/Conformances/UserNotifications.swift
+++ b/Sources/CustomDump/Conformances/UserNotifications.swift
@@ -73,20 +73,9 @@
         .alert
       ]
       #if os(iOS) || os(watchOS)
-        if #available(iOS 13, watchOS 6, *) {
-          allCases.append(.announcement)
-        }
+        self.append_iOS_13_watchOS_6(&allCases)
       #endif
-      if #available(iOS 12, tvOS 12, watchOS 5, *) {
-        allCases.append(contentsOf: [
-          .badge,
-          .carPlay,
-          .criticalAlert,
-          .providesAppNotificationSettings,
-          .provisional,
-          .sound,
-        ])
-      }
+      self.append_iOS_12_tvOS_12_watchOS_5(&allCases)
       for option in allCases {
         if options.contains(option) {
           children.append(.init(rawValue: option))
@@ -102,6 +91,31 @@
         unlabeledChildren: children,
         displayStyle: .set
       )
+    }
+
+    // NB: Workaround for Xcode 13.2's new, experimental build system. (Fixed in Xcode 13.3.)
+    //
+    //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
+    private func append_iOS_13_watchOS_6(_ allCases: inout [UNAuthorizationOptions]) {
+      if #available(iOS 13, watchOS 6, *) {
+        allCases.append(.announcement)
+      }
+    }
+
+    // NB: Workaround for Xcode 13.2's new, experimental build system. (Fixed in Xcode 13.3.)
+    //
+    //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
+    private func append_iOS_12_tvOS_12_watchOS_5(_ allCases: inout [UNAuthorizationOptions]) {
+      if #available(iOS 12, tvOS 12, watchOS 5, *) {
+        allCases.append(contentsOf: [
+          .badge,
+          .carPlay,
+          .criticalAlert,
+          .providesAppNotificationSettings,
+          .provisional,
+          .sound,
+        ])
+      }
     }
   }
 
@@ -193,7 +207,7 @@
       )
     }
 
-    // NB: Workaround for Xcode 13.2's new, experimental build system.
+    // NB: Workaround for Xcode 13.2's new, experimental build system. (Fixed in Xcode 13.3.)
     //
     //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
     private func appendBannerList(_ allCases: inout [UNNotificationPresentationOptions]) {

--- a/Sources/CustomDump/Conformances/UserNotifications.swift
+++ b/Sources/CustomDump/Conformances/UserNotifications.swift
@@ -72,9 +72,7 @@
       var allCases: [UNAuthorizationOptions] = [
         .alert
       ]
-      #if os(iOS) || os(watchOS)
-        self.append_iOS_13_watchOS_6(&allCases)
-      #endif
+      self.append_iOS_13_watchOS_6(&allCases)
       self.append_iOS_12_tvOS_12_watchOS_5(&allCases)
       for option in allCases {
         if options.contains(option) {
@@ -97,9 +95,11 @@
     //
     //     defaults write com.apple.dt.XCBuild EnableSwiftBuildSystemIntegration 1
     private func append_iOS_13_watchOS_6(_ allCases: inout [UNAuthorizationOptions]) {
-      if #available(iOS 13, watchOS 6, *) {
-        allCases.append(.announcement)
-      }
+      #if os(iOS) || os(watchOS)
+        if #available(iOS 13, watchOS 6, *) {
+          allCases.append(.announcement)
+        }
+      #endif
     }
 
     // NB: Workaround for Xcode 13.2's new, experimental build system. (Fixed in Xcode 13.3.)


### PR DESCRIPTION
Loosening the platform constraint meant the same kind of experimental build system bugs that were fixed in #30 were introduced all over again.

This PR includes new workarounds and should conditionally run CI against the new build system, as well.