### PR TITLE
Use `_typeName` instead of `String.init(reflecting:)`

### DIFF
--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -1,5 +1,5 @@
 func typeName(_ type: Any.Type) -> String {
-  var name = String(reflecting: type)
+  var name = _typeName(type)
   if let index = name.firstIndex(of: ".") {
     name.removeSubrange(...index)
   }


### PR DESCRIPTION
Small thing I noticed. We're relying on a strange implicit behavior of `String.init(reflecting:)`, but the standard library has an ABI-stable `_typeName` function we can rely on instead.