### PR TITLE
Add new helper protocols to dump to control which child nodes are included in the dump

### DIFF
--- a/Sources/CustomDump/CustomDumpChildren.swift
+++ b/Sources/CustomDump/CustomDumpChildren.swift
@@ -1,0 +1,97 @@
+/// Implement this protocol to exclude superclass nodes
+public protocol CustomDumpExcludeSuperclass {}
+
+/// Implement this protocol to ignore dumping child nodes
+///
+/// Using this protocol will make the type ignore the children completly and only print out the type name.
+/// This can be useful when something is irrelevant
+public protocol CustomDumpIgnoreChildNodes {}
+
+/// Properties to include child nodes. By default all child nodes are included but when this is implemented, only the values passed will be included in the dump
+///
+/// ```
+/// struct Human {
+/// let name = "Jimmy"
+/// }
+///
+/// struct User: CustomDumpIncludedChildNodesProvider {
+///   static var includedNodes: [String]? {
+///     [
+///       "name",
+///       "email",
+///       "friends",
+///     ]
+///   }
+///   let name = "John"
+///   let email = "john@me.com"
+///   let age = 97
+///   let friends = [
+///     "James",
+///     "Lilly",
+///     "Peter",
+///     "Remus",
+///   ]
+///   let human = Human()
+/// }
+/// ```
+/// The dump for this will produce
+/// ```
+/// User(
+///   name: "John",
+///   email: "john@me.com",
+///   friends: [
+///     [0]: "James",
+///     [1]: "Lilly",
+///     [2]: "Peter",
+///     [3]: "Remus"
+///   ]
+/// )
+/// ```
+public protocol CustomDumpIncludedChildNodesProvider {
+  /// Which nodes to include in the dump
+  static var includedNodes: [String]? { get }
+}
+
+/// Properties to exclude child nodes. This can be helpful when one or more fields are not relevant
+///
+/// ```
+/// struct Human {
+/// let name = "Jimmy"
+/// }
+///
+/// struct User: CustomDumpExcludedChildNodesProvider {
+///   static var excludedNodes: [String] {
+///     [
+///       "age",
+///       "friends"
+///     ]
+///   }
+///   let name = "John"
+///   let email = "john@me.com"
+///   let age = 97
+///   let friends = [
+///     "James",
+///     "Lilly",
+///     "Peter",
+///     "Remus",
+///   ]
+///   let human = Human()
+/// }
+/// ```
+/// The dump for this will produce
+/// ```
+/// User(
+///   name: "John",
+///   email: "john@me.com",
+///   friends: [
+///     [0]: "James",
+///     [1]: "Lilly",
+///     [2]: "Peter",
+///     [3]: "Remus"
+///   ]
+/// )
+/// ```
+public protocol CustomDumpExcludedChildNodesProvider {
+  /// Which nodes to exclude from the dump
+  static var excludedNodes: [String] { get }
+}

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -850,6 +850,77 @@ final class DumpTests: XCTestCase {
     )
   }
 
+  func testIncludedNodes() {
+    var dump = ""
+    class Human: CustomDumpIncludedChildNodesProvider {
+      static var includedNodes: [String]? {
+        [
+          "name",
+          "email",
+        ]
+      }
+      let name = "John"
+      let email = "john@me.com"
+      let age = 97
+    }
+
+    customDump(Human(), to: &dump)
+
+    XCTAssertNoDifference(
+      dump,
+      """
+      DumpTests.Human(
+        name: "John",
+        email: "john@me.com"
+      )
+      """
+    )
+  }
+
+  func testExcludedNodes() {
+    var dump = ""
+    class Human: CustomDumpExcludedChildNodesProvider {
+      static var excludedNodes: [String] {
+        [
+          "name",
+        ]
+      }
+      let name = "John"
+      let email = "john@me.com"
+      let age = 97
+    }
+
+    customDump(Human(), to: &dump)
+
+    XCTAssertNoDifference(
+      dump,
+      """
+      DumpTests.Human(
+        email: "john@me.com",
+        age: 97
+      )
+      """
+    )
+  }
+
+  func testIgnoreChildNodes() {
+    var dump = ""
+    class Human: CustomDumpIgnoreChildNodes {
+      let name = "John"
+      let email = "john@me.com"
+      let age = 97
+    }
+
+    customDump(Human(), to: &dump)
+
+    XCTAssertNoDifference(
+      dump,
+      """
+      DumpTests.Human(...)
+      """
+    )
+  }
+
   func testRepeatition() {
     class Human {
       let name = "John"
@@ -871,24 +942,25 @@ final class DumpTests: XCTestCase {
 
     XCTAssertNoDifference(
       dump,
-      """
-      [
-        [0]: DumpTests.Human(
-          name: "John",
-          email: "john@me.com",
-          age: 97
-        ),
-        [1]: DumpTests.Human(↩︎),
-        [2]: DumpTests.Human(
-          name: "John",
-          email: "john@me.com",
-          age: 97
-        ),
-        [3]: DumpTests.Human(↩︎)
-      ]
-      """
+       """
+       [
+         [0]: DumpTests.Human(
+           name: "John",
+           email: "john@me.com",
+           age: 97
+         ),
+         [1]: DumpTests.Human(↩︎),
+         [2]: DumpTests.Human(
+           name: "John",
+           email: "john@me.com",
+           age: 97
+         ),
+         [3]: DumpTests.Human(↩︎)
+       ]
+       """
     )
   }
+
 
   #if canImport(CoreGraphics)
     func testCoreGraphics() {


### PR DESCRIPTION
Draft because it is based off of #58.

**Motivation**

The Current method of using `CustomDumpReflectable` can be used to include/exclude properties from the resulting dump but it requires implementing a custom mirror as described in https://github.com/pointfreeco/swift-custom-dump/blob/c9b6b940d95c0a925c63f6858943415714d8a981/Sources/CustomDump/CustomDumpReflectable.swift#L30. So for example if someone wants to exclude one property from an object with 20 properties, it will require creating a map with 19 properties to create a custom mirror. With `CustomDumpExcludedChildNodesProvider` the same result can be achieved by 2-3 lines and a simple string based array.

Open to naming suggestions and improvements.