### PR TITLE
Add ids to second occurrence of a type within a dump

### DIFF
--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -36,11 +36,6 @@ public func customDump<T>(
   return value
 }
 
-private struct UniqueOccurance: Hashable {
-  let typeName: String
-  let objectId: ObjectIdentifier
-}
-
 /// Dumps the given value's contents using its mirror to the specified output stream.
 ///
 /// - Parameters:

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -144,7 +144,7 @@ public func customDump<T, TargetStream>(
         let id = idPerItem[item, default: occurence]
         idPerItem[item] = id
 
-        return id > 1 ? "<\(id)>" : ""
+        return id > 1 ? "#\(id)" : ""
       }
       if visitedItems.contains(item) {
         out.write("\(typeName(mirror.subjectType))\(id)(↩︎)")

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -160,7 +160,7 @@ public func customDump<T, TargetStream>(
         }
         dumpChildren(
           of: Mirror(value, children: children),
-          prefix: "\(typeName(mirror.subjectType))\(idString)(",
+          prefix: "\(typeName(mirror.subjectType))\(id)(",
           suffix: ")"
         )
       }

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -824,23 +824,23 @@ final class DumpTests: XCTestCase {
             name: "Virginia",
             parent: DumpTests.Parent(↩︎)
           ),
-          [1]: DumpTests.Child(
+          [1]: DumpTests.Child<2>(
             name: "Ronald",
             parent: DumpTests.Parent(↩︎)
           ),
-          [2]: DumpTests.Child(
+          [2]: DumpTests.Child<3>(
             name: "Fred",
             parent: DumpTests.Parent(↩︎)
           ),
-          [3]: DumpTests.Child(
+          [3]: DumpTests.Child<4>(
             name: "George",
             parent: DumpTests.Parent(↩︎)
           ),
-          [4]: DumpTests.Child(
+          [4]: DumpTests.Child<5>(
             name: "Percy",
             parent: DumpTests.Parent(↩︎)
           ),
-          [5]: DumpTests.Child(
+          [5]: DumpTests.Child<6>(
             name: "Charles",
             parent: DumpTests.Parent(↩︎)
           )
@@ -900,6 +900,7 @@ final class DumpTests: XCTestCase {
          [4]: DumpTests.Human<2>(↩︎),
          [5]: DumpTests.Human<2>(↩︎),
          [6]: DumpTests.User(
+           name: "John",
            email: "john@me.com",
            age: 97,
            human: DumpTests.Human(↩︎)
@@ -907,6 +908,7 @@ final class DumpTests: XCTestCase {
          [7]: DumpTests.User(↩︎),
          [8]: DumpTests.User(↩︎),
          [9]: DumpTests.User<2>(
+           name: "John",
            email: "john@me.com",
            age: 97,
            human: DumpTests.Human<2>(↩︎)

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -871,22 +871,22 @@ final class DumpTests: XCTestCase {
 
     XCTAssertNoDifference(
       dump,
-      """
-      [
-        [0]: DumpTests.Human(
-          name: "John",
-          email: "john@me.com",
-          age: 97
-        ),
-        [1]: DumpTests.Human(↩︎),
-        [2]: DumpTests.Human(
-          name: "John",
-          email: "john@me.com",
-          age: 97
-        ),
-        [3]: DumpTests.Human(↩︎)
-      ]
-      """
+       """
+       [
+         [0]: DumpTests.Human(
+           name: "John",
+           email: "john@me.com",
+           age: 97
+         ),
+         [1]: DumpTests.Human(↩︎),
+         [2]: DumpTests.Human<1>(
+           name: "John",
+           email: "john@me.com",
+           age: 97
+         ),
+         [3]: DumpTests.Human<1>(↩︎)
+       ]
+       """
     )
   }
 

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -853,38 +853,66 @@ final class DumpTests: XCTestCase {
   func testRepeatition() {
     class Human {
       let name = "John"
+    }
+
+    class User: Human {
       let email = "john@me.com"
       let age = 97
+
+      let human: Human
+
+      init(human: Human) {
+        self.human = human
+      }
     }
 
     let human = Human()
     let human2 = Human()
 
+    let user = User(human: human)
+    let user2 = User(human: human2)
+
     var dump = ""
     customDump(
-      [
-        human,
-        human,
-        human2,
-        human2,
-      ], to: &dump)
+    [
+      human,
+      human,
+      human,
+      human2,
+      human2,
+      human2,
+      user,
+      user,
+      user,
+      user2,
+      user2,
+      user2,
+    ], to: &dump)
 
     XCTAssertNoDifference(
       dump,
        """
        [
-         [0]: DumpTests.Human(
-           name: "John",
-           email: "john@me.com",
-           age: 97
-         ),
+         [0]: DumpTests.Human(name: "John"),
          [1]: DumpTests.Human(↩︎),
-         [2]: DumpTests.Human<1>(
-           name: "John",
+         [2]: DumpTests.Human(↩︎),
+         [3]: DumpTests.Human<2>(name: "John"),
+         [4]: DumpTests.Human<2>(↩︎),
+         [5]: DumpTests.Human<2>(↩︎),
+         [6]: DumpTests.User(
            email: "john@me.com",
-           age: 97
+           age: 97,
+           human: DumpTests.Human(↩︎)
          ),
-         [3]: DumpTests.Human<1>(↩︎)
+         [7]: DumpTests.User(↩︎),
+         [8]: DumpTests.User(↩︎),
+         [9]: DumpTests.User<2>(
+           email: "john@me.com",
+           age: 97,
+           human: DumpTests.Human<2>(↩︎)
+         ),
+         [10]: DumpTests.User<2>(↩︎),
+         [11]: DumpTests.User<2>(↩︎)
        ]
        """
     )

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -824,23 +824,23 @@ final class DumpTests: XCTestCase {
             name: "Virginia",
             parent: DumpTests.Parent(↩︎)
           ),
-          [1]: DumpTests.Child<2>(
+          [1]: DumpTests.Child#2(
             name: "Ronald",
             parent: DumpTests.Parent(↩︎)
           ),
-          [2]: DumpTests.Child<3>(
+          [2]: DumpTests.Child#3(
             name: "Fred",
             parent: DumpTests.Parent(↩︎)
           ),
-          [3]: DumpTests.Child<4>(
+          [3]: DumpTests.Child#4(
             name: "George",
             parent: DumpTests.Parent(↩︎)
           ),
-          [4]: DumpTests.Child<5>(
+          [4]: DumpTests.Child#5(
             name: "Percy",
             parent: DumpTests.Parent(↩︎)
           ),
-          [5]: DumpTests.Child<6>(
+          [5]: DumpTests.Child#6(
             name: "Charles",
             parent: DumpTests.Parent(↩︎)
           )
@@ -896,9 +896,9 @@ final class DumpTests: XCTestCase {
          [0]: DumpTests.Human(name: "John"),
          [1]: DumpTests.Human(↩︎),
          [2]: DumpTests.Human(↩︎),
-         [3]: DumpTests.Human<2>(name: "John"),
-         [4]: DumpTests.Human<2>(↩︎),
-         [5]: DumpTests.Human<2>(↩︎),
+         [3]: DumpTests.Human#2(name: "John"),
+         [4]: DumpTests.Human#2(↩︎),
+         [5]: DumpTests.Human#2(↩︎),
          [6]: DumpTests.User(
            name: "John",
            email: "john@me.com",
@@ -907,14 +907,14 @@ final class DumpTests: XCTestCase {
          ),
          [7]: DumpTests.User(↩︎),
          [8]: DumpTests.User(↩︎),
-         [9]: DumpTests.User<2>(
+         [9]: DumpTests.User#2(
            name: "John",
            email: "john@me.com",
            age: 97,
-           human: DumpTests.Human<2>(↩︎)
+           human: DumpTests.Human#2(↩︎)
          ),
-         [10]: DumpTests.User<2>(↩︎),
-         [11]: DumpTests.User<2>(↩︎)
+         [10]: DumpTests.User#2(↩︎),
+         [11]: DumpTests.User#2(↩︎)
        ]
        """
     )


### PR DESCRIPTION
Adding a unique id for occurrences of the same type.

**Motivation**
- Whenever the same object is repeated within a dump it gets completely redacted. This is done to avoid recursion but it can also mean that if there is the same object the appears multiple times for other reasons it still gets redacted
- If there is a repetition of multiple objects of the same type it removes the information about which object it is in the redacted state
- By assigning an id to each second or more occurrence of the same type we can identify which object it is easily