### PR TITLE
Update object identifier dump

### DIFF
--- a/Sources/CustomDump/Conformances/Swift.swift
+++ b/Sources/CustomDump/Conformances/Swift.swift
@@ -7,7 +7,7 @@ extension Character: CustomDumpRepresentable {
 extension ObjectIdentifier: CustomDumpStringConvertible {
   public var customDumpDescription: String {
     self.debugDescription
-      .replacingOccurrences(of: "0x0*", with: "0x", options: .regularExpression)
+      .replacingOccurrences(of: ":?\\s*0x[\\da-f]+(\\s*)", with: "$1", options: .regularExpression)
   }
 }
 

--- a/Tests/CustomDumpTests/Conformances/SwiftTests.swift
+++ b/Tests/CustomDumpTests/Conformances/SwiftTests.swift
@@ -17,6 +17,23 @@ final class SwiftTests: XCTestCase {
     )
   }
 
+  func testObjectIdentifier() {
+    let user = UserClass(id: 1, name: "")
+    let objectIdentifier = ObjectIdentifier(user)
+
+    var dump = ""
+    customDump(
+      objectIdentifier,
+      to: &dump
+    )
+    XCTAssertNoDifference(
+      dump,
+      """
+      ObjectIdentifier()
+      """
+    )
+  }
+
   func testStaticString() {
     let string: StaticString = "hello world!"
     var dump = ""


### PR DESCRIPTION
The `ObjectIdentifer` dump currently also prints the memory address which isn't ideal as that dump will never be matched. 