### PR TITLE
Abbreviate nested enums

### DIFF
--- a/Tests/CustomDumpTests/Conformances/FoundationTests.swift
+++ b/Tests/CustomDumpTests/Conformances/FoundationTests.swift
@@ -136,7 +136,7 @@ final class FoundationTests: XCTestCase {
       dump,
       """
       Calendar(
-        identifier: Calendar.Identifier.gregorian,
+        identifier: .gregorian,
         locale: Locale(),
         timeZone: TimeZone(
           identifier: "GMT",

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -242,6 +242,20 @@ final class DumpTests: XCTestCase {
       )
       """
     )
+
+    dump = ""
+    customDump(Nested.nest(.fizz(0.9, buzz: "2")), to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      Nested.nest(
+        .fizz(
+          0.9,
+          buzz: "2"
+        )
+      )
+      """
+    )
   }
 
   func testOptional() {
@@ -608,7 +622,7 @@ final class DumpTests: XCTestCase {
       dump,
       """
       Result.success(
-        Result.success(42)
+        .success(42)
       )
       """
     )

--- a/Tests/CustomDumpTests/Mocks.swift
+++ b/Tests/CustomDumpTests/Mocks.swift
@@ -41,6 +41,10 @@ enum Enum {
   case fu(bar: Int)
 }
 
+enum Nested {
+  case nest(Enum)
+}
+
 enum Namespaced {
   class Class {
     var x: Int


### PR DESCRIPTION
We can use dot-abbreviation to keep descriptions short but provide enough context.