### PR TITLE
Abbreviate enums in diffs

### DIFF
--- a/Sources/CustomDump/Conformances/SwiftUI.swift
+++ b/Sources/CustomDump/Conformances/SwiftUI.swift
@@ -22,6 +22,7 @@
           Mirror(reflecting: self).children.first?.value as Any,
           name: nil,
           indent: 2,
+          isRoot: true,
           maxDepth: .max
         )
         return """

--- a/Sources/CustomDump/Conformances/SwiftUI.swift
+++ b/Sources/CustomDump/Conformances/SwiftUI.swift
@@ -22,7 +22,7 @@
           Mirror(reflecting: self).children.first?.value as Any,
           name: nil,
           indent: 2,
-          isRoot: true,
+          isRoot: false,
           maxDepth: .max
         )
         return """

--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -34,11 +34,12 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
     lhsName: String?,
     rhsName: String?,
     separator: String,
-    indent: Int
+    indent: Int,
+    isRoot: Bool
   ) -> String {
     let rhsName = rhsName ?? lhsName
     guard !isMirrorEqual(lhs, rhs) else {
-      return _customDump(lhs, name: rhsName, indent: indent, maxDepth: 0)
+      return _customDump(lhs, name: rhsName, indent: indent, isRoot: isRoot, maxDepth: 0)
         .appending(separator)
         .indenting(with: format.both + " ")
     }
@@ -48,8 +49,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
     var out = ""
 
     func diffEverything() {
-      var lhs = _customDump(lhs, name: lhsName, indent: indent, maxDepth: .max)
-      var rhs = _customDump(rhs, name: rhsName, indent: indent, maxDepth: .max)
+      var lhs = _customDump(lhs, name: lhsName, indent: indent, isRoot: isRoot, maxDepth: .max)
+      var rhs = _customDump(rhs, name: rhsName, indent: indent, isRoot: isRoot, maxDepth: .max)
       if lhs == rhs {
         if lhsMirror.subjectType != rhsMirror.subjectType {
           lhs.append(" as \(typeName(lhsMirror.subjectType))")
@@ -104,6 +105,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
             lhs,
             name: lhsName,
             indent: indent,
+            isRoot: false,
             maxDepth: 0
           )
           .indenting(with: format.first + " "),
@@ -114,6 +116,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
             rhs,
             name: rhsName,
             indent: indent,
+            isRoot: false,
             maxDepth: 0
           )
           .indenting(with: format.second + " "),
@@ -130,6 +133,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
             lhs,
             name: lhsName,
             indent: indent,
+            isRoot: isRoot,
             maxDepth: .max
           )
           .indenting(with: format.first + " "),
@@ -140,6 +144,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
             rhs,
             name: rhsName,
             indent: indent,
+            isRoot: isRoot,
             maxDepth: .max
           )
           .indenting(with: format.second + " "),
@@ -178,6 +183,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
               child.value,
               name: child.label,
               indent: indent + elementIndent,
+              isRoot: false,
               maxDepth: 0
             )
             .indenting(with: format.both + " "),
@@ -234,7 +240,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
               separator: lhsOffset == lhsChildren.count - 1 && rhsOffset == rhsChildren.count - 1
                 ? ""
                 : elementSeparator,
-              indent: indent + elementIndent
+              indent: indent + elementIndent,
+              isRoot: false
             ),
             to: &out
           )
@@ -250,6 +257,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
               lhsChild.value,
               name: lhsChild.label,
               indent: indent + elementIndent,
+              isRoot: false,
               maxDepth: .max
             )
             .indenting(with: format.first + " "),
@@ -266,6 +274,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
               rhsChild.value,
               name: rhsChild.label,
               indent: indent + elementIndent,
+              isRoot: false,
               maxDepth: .max
             )
             .indenting(with: format.second + " "),
@@ -301,7 +310,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           lhsName: lhsName,
           rhsName: rhsName,
           separator: separator,
-          indent: indent
+          indent: indent,
+          isRoot: isRoot
         )
       )
 
@@ -385,16 +395,16 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
             let lhs = $0.value as? (key: AnyHashable, value: Any),
             let rhs = $1.value as? (key: AnyHashable, value: Any)
           else {
-            return _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
-              < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
+            return _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
+              < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
           }
-          return _customDump(lhs.key.base, name: nil, indent: 0, maxDepth: 1)
-            < _customDump(rhs.key.base, name: nil, indent: 0, maxDepth: 1)
+          return _customDump(lhs.key.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
+            < _customDump(rhs.key.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
         }
       ) { child, _ in
         guard let pair = child.value as? (key: AnyHashable, value: Any) else { return }
         child = (
-          _customDump(pair.key.base, name: nil, indent: 0, maxDepth: 1),
+          _customDump(pair.key.base, name: nil, indent: 0, isRoot: false, maxDepth: 1),
           pair.value
         )
       }
@@ -420,7 +430,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
         ? rhsChildMirror
         : Mirror(rhs, unlabeledChildren: [rhsChild.value], displayStyle: .tuple)
 
-      let subjectType = typeName(lhsMirror.subjectType)
+      let subjectType = isRoot ? typeName(lhsMirror.subjectType) : ""
       diffChildren(
         lhsAssociatedValuesMirror,
         rhsAssociatedValuesMirror,
@@ -452,7 +462,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           lhsName: lhsName,
           rhsName: rhsName,
           separator: separator,
-          indent: indent
+          indent: indent,
+          isRoot: isRoot
         )
       )
 
@@ -469,8 +480,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
         },
         areInIncreasingOrder: {
-          _customDump($0.value, name: nil, indent: 0, maxDepth: 1)
-            < _customDump($1.value, name: nil, indent: 0, maxDepth: 1)
+          _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
+            < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
         }
       )
 
@@ -545,7 +556,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
 
   guard !isMirrorEqual(lhs, rhs) else { return nil }
 
-  var diff = diffHelp(lhs, rhs, lhsName: nil, rhsName: nil, separator: "", indent: 0)
+  var diff = diffHelp(lhs, rhs, lhsName: nil, rhsName: nil, separator: "", indent: 0, isRoot: true)
   if diff.last == "\n" { diff.removeLast() }
   return diff
 }

--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -533,7 +533,10 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
               .split(separator: "\n", omittingEmptySubsequences: false)
               .map(Line.init(rawValue:))
         )
-        let hashes = String(repeating: "#", count: max(lhs.hashCount, rhs.hashCount))
+        let hashes = String(
+          repeating: "#",
+          count: max(lhs.hashCount(isMultiline: true), rhs.hashCount(isMultiline: true))
+        )
         diffChildren(
           lhsMirror,
           rhsMirror,

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -276,12 +276,15 @@ func _customDump<T, TargetStream>(
           if maxDepth == 0 {
             out.write("\"…\"")
           } else {
-            let hashes = String(repeating: "#", count: value.hashCount)
+            let hashes = String(repeating: "#", count: value.hashCount(isMultiline: true))
             out.write("\(hashes)\"\"\"")
             out.write("\n")
             print(value.indenting(by: name != nil ? 2 : 0), to: &out)
             out.write(name != nil ? "  \"\"\"\(hashes)" : "\"\"\"\(hashes)")
           }
+        } else if value.contains("\"") {
+          let hashes = String(repeating: "#", count: max(value.hashCount(isMultiline: false), 1))
+          out.write("\(hashes)\"\(value)\"\(hashes)")
         } else {
           out.write(value.debugDescription)
         }

--- a/Sources/CustomDump/Internal/Box.swift
+++ b/Sources/CustomDump/Internal/Box.swift
@@ -23,6 +23,10 @@ func isMirrorEqual(_ lhs: Any, _ rhs: Any) -> Bool {
     lhsMirror.subjectType == rhsMirror.subjectType,
     lhsMirror.children.count == rhsMirror.children.count
   else { return false }
+  guard !lhsMirror.children.isEmpty, !rhsMirror.children.isEmpty
+  else {
+    return String(describing: lhs) == String(describing: rhs)
+  }
   for (lhsChild, rhsChild) in zip(lhsMirror.children, rhsMirror.children) {
     guard
       lhsChild.label == rhsChild.label,

--- a/Sources/CustomDump/Internal/String.swift
+++ b/Sources/CustomDump/Internal/String.swift
@@ -18,7 +18,7 @@ extension String {
     while let range = substring.range(of: pattern, options: .regularExpression) {
       let count = substring.distance(from: range.lowerBound, to: range.upperBound) - offset
       hashCount = max(count, hashCount)
-      substring.removeSubrange(..<range.upperBound)
+      substring = substring[range.upperBound...]
     }
     return hashCount
   }

--- a/Sources/CustomDump/Internal/String.swift
+++ b/Sources/CustomDump/Internal/String.swift
@@ -10,11 +10,13 @@ extension String {
     return "\(prefix)\(self.replacingOccurrences(of: "\n", with: "\n\(prefix)"))"
   }
 
-  var hashCount: Int {
+  func hashCount(isMultiline: Bool) -> Int {
+    let (quote, offset) = isMultiline ? ("\"\"\"", 2) : ("\"", 0)
     var substring = self[...]
     var hashCount = 0
-    while let range = substring.range(of: "([#]*\"\"\"|\"\"\"[#]*)", options: .regularExpression) {
-      let count = substring.distance(from: range.lowerBound, to: range.upperBound) - 2
+    let pattern = "(\(quote)[#]*)"
+    while let range = substring.range(of: pattern, options: .regularExpression) {
+      let count = substring.distance(from: range.lowerBound, to: range.upperBound) - offset
       hashCount = max(count, hashCount)
       substring.removeSubrange(..<range.upperBound)
     }

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -298,6 +298,58 @@ final class DiffTests: XCTestCase {
         )
       """
     )
+
+    XCTAssertNoDifference(
+      diff(
+        Nested.nest(.fizz(42, buzz: "Blob")),
+        Nested.nest(.fizz(42, buzz: "Glob"))
+      ),
+      """
+        Nested.nest(
+          .fizz(
+            42.0,
+      -     buzz: "Blob"
+      +     buzz: "Glob"
+          )
+        )
+      """
+    )
+
+    XCTAssertNoDifference(
+      diff(
+        Enum.foo,
+        Enum.buzz
+      ),
+      """
+      - Enum.foo
+      + Enum.buzz
+      """
+    )
+
+    XCTAssertNoDifference(
+      diff(
+        Nested.nest(.foo),
+        Nested.nest(.buzz)
+      ),
+      """
+      - Nested.nest(.foo)
+      + Nested.nest(.buzz)
+      """
+    )
+
+    XCTAssertNoDifference(
+      diff(
+        Nested.largerNest(1, .foo),
+        Nested.largerNest(1, .buzz)
+      ),
+      """
+        Nested.largerNest(
+          1,
+      -   .foo
+      +   .buzz
+        )
+      """
+    )
   }
 
   func testOptional() {

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -412,6 +412,29 @@ final class DumpTests: XCTestCase {
     )
   }
 
+  func testString() {
+    var dump = ""
+    customDump("Hello!", to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      #""Hello!""#
+    )
+
+    dump = ""
+    customDump(#"Hello, "world!""#, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      ##"#"Hello, "world!""#"##
+    )
+
+    dump = ""
+    customDump(####"This has a "### in it"####, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      #####"####"This has a "### in it"####"#####
+    )
+  }
+
   func testMultilineString() {
     var dump = ""
     customDump("Hello,\nWorld!", to: &dump)

--- a/Tests/CustomDumpTests/Mocks.swift
+++ b/Tests/CustomDumpTests/Mocks.swift
@@ -39,10 +39,12 @@ enum Enum {
   case baz(fizz: Double, buzz: String)
   case fizz(Double, buzz: String)
   case fu(bar: Int)
+  case buzz
 }
 
 enum Nested {
   case nest(Enum)
+  case largerNest(Int, Enum)
 }
 
 enum Namespaced {


### PR DESCRIPTION
We added the ability to abbreviate nested dumps in #71, but this didn't transfer to diffs.