### PR TITLE
Use `AnyKeyPath.customDebugDescription` when possible

### DIFF
--- a/Sources/CustomDump/Conformances/KeyPath.swift
+++ b/Sources/CustomDump/Conformances/KeyPath.swift
@@ -1,11 +1,11 @@
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-  extension AnyKeyPath: CustomDumpStringConvertible {
-    public var customDumpDescription: String {
-      #if swift(>=5.8)
-        if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
-          return self.debugDescription
-        }
-      #endif
+extension AnyKeyPath: CustomDumpStringConvertible {
+  public var customDumpDescription: String {
+    #if swift(>=5.8)
+      if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
+        return self.debugDescription
+      }
+    #endif
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
       guard let name = keyPathToName[self] else {
         func reflectName() -> String {
           var namedKeyPaths = Reflection.allNamedKeyPaths(forUnderlyingTypeOf: Self.rootType)
@@ -29,9 +29,13 @@
         return name
       }
       return name
-    }
+    #else
+      return "\(typeName(Self.self))<\(typeName(Self.rootType)), \(typeName(Self.valueType))>"
+    #endif
   }
+}
 
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   private var keyPathToName: [AnyKeyPath: String] = [:]
 
   // The source code below was extracted from the "KeyPath Reflection" branch of Apple's

--- a/Sources/CustomDump/Conformances/KeyPath.swift
+++ b/Sources/CustomDump/Conformances/KeyPath.swift
@@ -30,7 +30,7 @@ extension AnyKeyPath: CustomDumpStringConvertible {
       }
       return name
     #else
-      return "\(typeName(Self.self))<\(typeName(Self.rootType)), \(typeName(Self.valueType))>"
+      return typeName(Self.self, genericsAbbreviated: false)
     #endif
   }
 }

--- a/Sources/CustomDump/Conformances/KeyPath.swift
+++ b/Sources/CustomDump/Conformances/KeyPath.swift
@@ -1,6 +1,11 @@
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   extension AnyKeyPath: CustomDumpStringConvertible {
     public var customDumpDescription: String {
+      #if swift(>=5.8)
+        if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
+          return self.debugDescription
+        }
+      #endif
       guard let name = keyPathToName[self] else {
         func reflectName() -> String {
           var namedKeyPaths = Reflection.allNamedKeyPaths(forUnderlyingTypeOf: Self.rootType)

--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -5,7 +5,7 @@ func typeName(
 ) -> String {
   var name = _typeName(type, qualified: qualified)
     .replacingOccurrences(
-      of: #"\b\w+\.([^\b]+)"#,
+      of: #"\w+\.(\w+)"#,
       with: "$1",
       options: .regularExpression
     )

--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -1,13 +1,25 @@
-func typeName(_ type: Any.Type) -> String {
-  var name = _typeName(type)
-  if let index = name.firstIndex(of: ".") {
-    name.removeSubrange(...index)
-  }
-  return
-    name
+func typeName(
+  _ type: Any.Type,
+  qualified: Bool = true,
+  genericsAbbreviated: Bool = true
+) -> String {
+  var name = _typeName(type, qualified: qualified)
     .replacingOccurrences(
-      of: #"<.+>|\(unknown context at \$[[:xdigit:]]+\)\."#,
+      of: #"\w+.(\w+)"#,
+      with: "$1",
+      options: .regularExpression
+    )
+    .replacingOccurrences(
+      of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
       with: "",
       options: .regularExpression
     )
+  if genericsAbbreviated {
+    name = name.replacingOccurrences(
+      of: #"<.+>"#,
+      with: "",
+      options: .regularExpression
+    )
+  }
+  return name
 }

--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -5,7 +5,7 @@ func typeName(
 ) -> String {
   var name = _typeName(type, qualified: qualified)
     .replacingOccurrences(
-      of: #"\w+.(\w+)"#,
+      of: #"\b\w+\.([^\b]+)"#,
       with: "$1",
       options: .regularExpression
     )

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -957,7 +957,7 @@ final class DiffTests: XCTestCase {
       diff(
         [
           "value": 29.99 as Float
-        ],
+        ] as [String: Any],
         [
           "value": 29.99 as Double
         ]

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -577,43 +577,112 @@ final class DumpTests: XCTestCase {
     func testKeyPath() {
       var dump = ""
 
-      // Run twice to exercise cached lookup
-      for _ in 1...2 {
-        dump = ""
-        customDump(\UserClass.name, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          \UserClass.name
-          """#
-        )
+      @propertyWrapper
+      struct Wrapped<Value> {
+        var wrappedValue: Value
+        var projectedValue: Self { self }
+      }
 
-        dump = ""
-        customDump(\Pair.driver.name, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          \Pair.driver.name
-          """#
-        )
+      struct Item {
+        @Wrapped var isInStock = true
+      }
 
-        dump = ""
-        customDump(\User.name.count, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          KeyPath<User, Int>
-          """#
-        )
+      if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
+        // Run twice to exercise cached lookup
+        for _ in 1...2 {
+          dump = ""
+          customDump(\UserClass.name, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \UserClass.name
+            """#
+          )
 
-        dump = ""
-        customDump(\(x: Double, y: Double).x, to: &dump)
-        XCTAssertNoDifference(
-          dump,
-          #"""
-          WritableKeyPath<(x: Double, y: Double), Double>
-          """#
-        )
+          dump = ""
+          customDump(\Pair.driver.name, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \Pair.driver.name
+            """#
+          )
+
+          dump = ""
+          customDump(\User.name.count, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \User.name.count
+            """#
+          )
+
+          dump = ""
+          customDump(\(x: Double, y: Double).x, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \(x: Double, y: Double).x
+            """#
+          )
+
+          dump = ""
+          customDump(\Item.$isInStock, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \Item.$isInStock
+            """#
+          )
+        }
+      } else {
+        // Run twice to exercise cached lookup
+        for _ in 1...2 {
+          dump = ""
+          customDump(\UserClass.name, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \UserClass.name
+            """#
+          )
+
+          dump = ""
+          customDump(\Pair.driver.name, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            \Pair.driver.name
+            """#
+          )
+
+          dump = ""
+          customDump(\User.name.count, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            KeyPath<User, Int>
+            """#
+          )
+
+          dump = ""
+          customDump(\(x: Double, y: Double).x, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            WritableKeyPath<(x: Double, y: Double), Double>
+            """#
+          )
+
+          dump = ""
+          customDump(\Item.$isInStock, to: &dump)
+          XCTAssertNoDifference(
+            dump,
+            #"""
+            KeyPath<Item, Wrapped<Bool>>
+            """#
+          )
+        }
       }
     }
   #endif

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -573,69 +573,66 @@ final class DumpTests: XCTestCase {
     )
   }
 
-  #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    func testKeyPath() {
-      var dump = ""
+  func testKeyPath() {
+    var dump = ""
 
-      @propertyWrapper
-      struct Wrapped<Value> {
-        var wrappedValue: Value
-        var projectedValue: Self { self }
-      }
+    @propertyWrapper
+    struct Wrapped<Value> {
+      var wrappedValue: Value
+      var projectedValue: Self { self }
+    }
 
-      struct Item {
-        @Wrapped var isInStock = true
-      }
+    struct Item {
+      @Wrapped var isInStock = true
+    }
 
-      if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
-        // Run twice to exercise cached lookup
-        for _ in 1...2 {
-          dump = ""
-          customDump(\UserClass.name, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \UserClass.name
-            """#
-          )
+    if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
+      dump = ""
+      customDump(\UserClass.name, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        \UserClass.name
+        """#
+      )
 
-          dump = ""
-          customDump(\Pair.driver.name, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \Pair.driver.name
-            """#
-          )
+      dump = ""
+      customDump(\Pair.driver.name, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        \Pair.driver.name
+        """#
+      )
 
-          dump = ""
-          customDump(\User.name.count, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \User.name.count
-            """#
-          )
+      dump = ""
+      customDump(\User.name.count, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        \User.name.count
+        """#
+      )
 
-          dump = ""
-          customDump(\(x: Double, y: Double).x, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \(x: Double, y: Double).x
-            """#
-          )
+      dump = ""
+      customDump(\(x: Double, y: Double).x, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        \(x: Double, y: Double).x
+        """#
+      )
 
-          dump = ""
-          customDump(\Item.$isInStock, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \Item.$isInStock
-            """#
-          )
-        }
-      } else {
+      dump = ""
+      customDump(\Item.$isInStock, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        \Item.$isInStock
+        """#
+      )
+    } else {
+      #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
         // Run twice to exercise cached lookup
         for _ in 1...2 {
           dump = ""
@@ -683,9 +680,54 @@ final class DumpTests: XCTestCase {
             """#
           )
         }
-      }
+      #else
+        dump = ""
+        customDump(\UserClass.name, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          KeyPath<UserClass, String>
+          """#
+        )
+
+        dump = ""
+        customDump(\Pair.driver.name, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          KeyPath<Pair, String>
+          """#
+        )
+
+        dump = ""
+        customDump(\User.name.count, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          KeyPath<User, Int>
+          """#
+        )
+
+        dump = ""
+        customDump(\(x: Double, y: Double).x, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          WritableKeyPath<(x: Double, y: Double), Double>
+          """#
+        )
+
+        dump = ""
+        customDump(\Item.$isInStock, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          KeyPath<Item, Wrapped<Bool>>
+          """#
+        )
+      #endif
     }
-  #endif
+  }
 
   func testNamespacedTypes() {
     var dump = ""

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -576,16 +576,6 @@ final class DumpTests: XCTestCase {
   func testKeyPath() {
     var dump = ""
 
-    @propertyWrapper
-    struct Wrapped<Value> {
-      var wrappedValue: Value
-      var projectedValue: Self { self }
-    }
-
-    struct Item {
-      @Wrapped var isInStock = true
-    }
-
     #if swift(>=5.8)
       if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
         dump = ""

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -586,107 +586,14 @@ final class DumpTests: XCTestCase {
       @Wrapped var isInStock = true
     }
 
-    if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
-      dump = ""
-      customDump(\UserClass.name, to: &dump)
-      XCTAssertNoDifference(
-        dump,
-        #"""
-        \UserClass.name
-        """#
-      )
-
-      dump = ""
-      customDump(\Pair.driver.name, to: &dump)
-      XCTAssertNoDifference(
-        dump,
-        #"""
-        \Pair.driver.name
-        """#
-      )
-
-      dump = ""
-      customDump(\User.name.count, to: &dump)
-      XCTAssertNoDifference(
-        dump,
-        #"""
-        \User.name.count
-        """#
-      )
-
-      dump = ""
-      customDump(\(x: Double, y: Double).x, to: &dump)
-      XCTAssertNoDifference(
-        dump,
-        #"""
-        \(x: Double, y: Double).x
-        """#
-      )
-
-      dump = ""
-      customDump(\Item.$isInStock, to: &dump)
-      XCTAssertNoDifference(
-        dump,
-        #"""
-        \Item.$isInStock
-        """#
-      )
-    } else {
-      #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-        // Run twice to exercise cached lookup
-        for _ in 1...2 {
-          dump = ""
-          customDump(\UserClass.name, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \UserClass.name
-            """#
-          )
-
-          dump = ""
-          customDump(\Pair.driver.name, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            \Pair.driver.name
-            """#
-          )
-
-          dump = ""
-          customDump(\User.name.count, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            KeyPath<User, Int>
-            """#
-          )
-
-          dump = ""
-          customDump(\(x: Double, y: Double).x, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            WritableKeyPath<(x: Double, y: Double), Double>
-            """#
-          )
-
-          dump = ""
-          customDump(\Item.$isInStock, to: &dump)
-          XCTAssertNoDifference(
-            dump,
-            #"""
-            KeyPath<Item, Wrapped<Bool>>
-            """#
-          )
-        }
-      #else
+    #if swift(>=5.8)
+      if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
         dump = ""
         customDump(\UserClass.name, to: &dump)
         XCTAssertNoDifference(
           dump,
           #"""
-          KeyPath<UserClass, String>
+          \UserClass.name
           """#
         )
 
@@ -695,7 +602,57 @@ final class DumpTests: XCTestCase {
         XCTAssertNoDifference(
           dump,
           #"""
-          KeyPath<Pair, String>
+          \Pair.driver.name
+          """#
+        )
+
+        dump = ""
+        customDump(\User.name.count, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          \User.name.count
+          """#
+        )
+
+        dump = ""
+        customDump(\(x: Double, y: Double).x, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          \(x: Double, y: Double).x
+          """#
+        )
+
+        dump = ""
+        customDump(\Item.$isInStock, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          \Item.$isInStock
+          """#
+        )
+        return
+      }
+    #endif
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+      // Run twice to exercise cached lookup
+      for _ in 1...2 {
+        dump = ""
+        customDump(\UserClass.name, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          \UserClass.name
+          """#
+        )
+
+        dump = ""
+        customDump(\Pair.driver.name, to: &dump)
+        XCTAssertNoDifference(
+          dump,
+          #"""
+          \Pair.driver.name
           """#
         )
 
@@ -725,8 +682,53 @@ final class DumpTests: XCTestCase {
           KeyPath<Item, Wrapped<Bool>>
           """#
         )
-      #endif
-    }
+      }
+    #else
+      dump = ""
+      customDump(\UserClass.name, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        KeyPath<UserClass, String>
+        """#
+      )
+
+      dump = ""
+      customDump(\Pair.driver.name, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        KeyPath<Pair, String>
+        """#
+      )
+
+      dump = ""
+      customDump(\User.name.count, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        KeyPath<User, Int>
+        """#
+      )
+
+      dump = ""
+      customDump(\(x: Double, y: Double).x, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        WritableKeyPath<(x: Double, y: Double), Double>
+        """#
+      )
+
+      dump = ""
+      customDump(\Item.$isInStock, to: &dump)
+      XCTAssertNoDifference(
+        dump,
+        #"""
+        KeyPath<Item, Wrapped<Bool>>
+        """#
+      )
+    #endif
   }
 
   func testNamespacedTypes() {

--- a/Tests/CustomDumpTests/Mocks.swift
+++ b/Tests/CustomDumpTests/Mocks.swift
@@ -129,3 +129,13 @@ struct Redacted<RawValue>: CustomDumpStringConvertible {
 
 struct User: Equatable, Identifiable { var id: Int, name: String }
 struct HashableUser: Equatable, Identifiable, Hashable { var id: Int, name: String }
+
+@propertyWrapper
+struct Wrapped<Value> {
+  var wrappedValue: Value
+  var projectedValue: Self { self }
+}
+
+struct Item {
+  @Wrapped var isInStock = true
+}


### PR DESCRIPTION
New in Swift 5.8 with implementation of [SE-0369](https://github.com/apple/swift-evolution/blob/main/proposals/0369-add-customdebugdescription-conformance-to-anykeypath.md).