### PR TITLE
Add XCTAssertNoDifference overload without Equatable requirement

### DIFF
--- a/Sources/CustomDump/XCTAssertNoDifference.swift
+++ b/Sources/CustomDump/XCTAssertNoDifference.swift
@@ -90,3 +90,79 @@ public func XCTAssertNoDifference<T>(
     )
   }
 }
+
+/// Asserts that two non-`Equatable` values have no difference.
+///
+/// Similar to `XCTAssertEqual`, but that function uses either `TextOutputStreamable`,
+/// `CustomStringConvertible` or `CustomDebugStringConvertible` in order to display a failure
+/// message:
+///
+/// ```swift
+/// XCTAssertEqual(user1, user2)
+/// ```
+/// ```text
+/// XCTAssertEqual failed: ("User(id: 42, name: "Blob")") is not equal to ("User(id: 42, name: "Blob, Esq.")")
+/// ```
+///
+/// `XCTAssertNoDifference` uses the output of ``diff(_:_:format:)`` to display a failure message,
+/// which helps highlight the differences between the given values:
+///
+/// ```swift
+/// XCTAssertNoDifference(user1, user2)
+/// ```
+/// ```text
+/// XCTAssertNoDifference failed: …
+///
+///     User(
+///       id: 42,
+///   -   name: "Blob"
+///   +   name: "Blob, Esq."
+///     )
+///
+/// (First: -, Second: +)
+/// ```
+///
+/// - Parameters:
+///   - expression1: An expression of type `T`.
+///   - expression2: A second expression of type `T`.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where
+///     you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you
+///     call this function.
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+public func XCTAssertNoDifference<T>(
+  _ expression1: @autoclosure () throws -> T,
+  _ expression2: @autoclosure () throws -> T,
+  _ message: @autoclosure () -> String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  do {
+    let expression1 = try expression1()
+    let expression2 = try expression2()
+    let format = DiffFormat.proportional
+    guard let difference = diff(expression1, expression2, format: format) else { return }
+    let failure = """
+      XCTAssertNoDifference failed: …
+
+      \(difference.indenting(by: 2))
+
+      (First: \(format.first), Second: \(format.second))
+      """
+    let message = message()
+    XCTFail(
+      "\(failure)\(message.isEmpty ? "" : " - \(message)")",
+      file: file,
+      line: line
+    )
+  } catch {
+    XCTFail(
+      """
+      XCTAssertNoDifference failed: threw error "\(error)"
+      """,
+      file: file,
+      line: line
+    )
+  }
+}

--- a/Sources/CustomDump/XCTAssertNoDifference.swift
+++ b/Sources/CustomDump/XCTAssertNoDifference.swift
@@ -50,7 +50,6 @@ public func XCTAssertNoDifference<T>(
   do {
     let expression1 = try expression1()
     let expression2 = try expression2()
-    let message = message()
     guard expression1 != expression2 else { return }
     let format = DiffFormat.proportional
     guard let difference = diff(expression1, expression2, format: format)
@@ -75,6 +74,7 @@ public func XCTAssertNoDifference<T>(
 
       (First: \(format.first), Second: \(format.second))
       """
+    let message = message()
     XCTFail(
       "\(failure)\(message.isEmpty ? "" : " - \(message)")",
       file: file,

--- a/Tests/CustomDumpTests/XCTAssertNoDifferenceTests.swift
+++ b/Tests/CustomDumpTests/XCTAssertNoDifferenceTests.swift
@@ -13,5 +13,52 @@ class XCTAssertNoDifferenceTests: XCTestCase {
 
       XCTAssertNoDifference(user, other)
     }
+
+    func testXCTAssertNoDifferenceNonEquatable() {
+      struct Thing {
+        indirect enum Choice { case a, b(String), c(Thing) }
+        var id: Int
+        var choice: Choice
+      }
+
+      let thing1 = Thing(id: 1, choice: .a)
+      let thing2 = Thing(id: 2, choice: .a)
+      let thing3 = Thing(id: 1, choice: .b(""))
+      let thing4 = Thing(id: 1, choice: .b("x"))
+      let thing5 = Thing(id: 1, choice: .c(thing))
+      let thing6 = Thing(id: 1, choice: .c(thing2))
+
+      #if compiler(>=5.7)
+        XCTAssertFalse(thing1 is any Equatable)
+        XCTAssertFalse(thing1.choice is any Equatable)
+      #endif
+
+      XCTAssertNoDifference(thing1, thing1)
+      XCTAssertNoDifference(thing2, thing2)
+      XCTAssertNoDifference(thing3, thing3)
+      XCTAssertNoDifference(thing4, thing4)
+      XCTAssertNoDifference(thing5, thing5)
+      XCTAssertNoDifference(thing6, thing6)
+
+      XCTExpectFailure { XCTAssertNoDifference(thing1, thing2) }
+      XCTExpectFailure { XCTAssertNoDifference(thing1, thing3) }
+      XCTExpectFailure { XCTAssertNoDifference(thing1, thing4) }
+      XCTExpectFailure { XCTAssertNoDifference(thing1, thing5) }
+      XCTExpectFailure { XCTAssertNoDifference(thing1, thing6) }
+
+      XCTExpectFailure { XCTAssertNoDifference(thing2, thing3) }
+      XCTExpectFailure { XCTAssertNoDifference(thing2, thing4) }
+      XCTExpectFailure { XCTAssertNoDifference(thing2, thing5) }
+      XCTExpectFailure { XCTAssertNoDifference(thing2, thing6) }
+
+      XCTExpectFailure { XCTAssertNoDifference(thing3, thing4) }
+      XCTExpectFailure { XCTAssertNoDifference(thing3, thing5) }
+      XCTExpectFailure { XCTAssertNoDifference(thing3, thing6) }
+
+      XCTExpectFailure { XCTAssertNoDifference(thing4, thing5) }
+      XCTExpectFailure { XCTAssertNoDifference(thing4, thing6) }
+
+      XCTExpectFailure { XCTAssertNoDifference(thing5, thing6) }
+    }
   #endif
 }


### PR DESCRIPTION
Sometimes we only need `Equatable` conformance for the purpose of unit tests. But with `CustomDump.diff`, we don't necessarily need `Equatable` conformance if we're willing to pay the performance hit of reflection and implicit opening of existentials during tests for a [decreased application binary size](https://forums.swift.org/t/allow-equable-to-be-used-in-other-files-especially-in-test-files/63497).

The proposed `XCTAssertNoDifference(lhs, rhs)` overload in this PR allows asserting on non-`Equatable` values.