### PR TITLE
Fix regression in `typeName` output

### DIFF
--- a/Sources/CustomDump/Conformances/KeyPath.swift
+++ b/Sources/CustomDump/Conformances/KeyPath.swift
@@ -35,7 +35,11 @@ extension AnyKeyPath: CustomDumpStringConvertible {
       }
       return name
     #else
-      return typeName(Self.self, genericsAbbreviated: false)
+      return """
+        \(typeName(Self.self))<\
+        \(typeName(Self.rootType)), \
+        \(typeName(Self.valueType,genericsAbbreviated: false))>
+        """
     #endif
   }
 }

--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -5,7 +5,7 @@ func typeName(
 ) -> String {
   var name = _typeName(type, qualified: qualified)
     .replacingOccurrences(
-      of: #"\w+\.(\w+)"#,
+      of: #"^\w+\.(\w+)"#,
       with: "$1",
       options: .regularExpression
     )

--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -5,13 +5,13 @@ func typeName(
 ) -> String {
   var name = _typeName(type, qualified: qualified)
     .replacingOccurrences(
-      of: #"^\w+\.(\w+)"#,
-      with: "$1",
+      of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
+      with: "",
       options: .regularExpression
     )
     .replacingOccurrences(
-      of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
-      with: "",
+      of: #"\w+\.([\w.]+)"#,
+      with: "$1",
       options: .regularExpression
     )
   if genericsAbbreviated {

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -36,6 +36,15 @@ final class DumpTests: XCTestCase {
       DumpTests.Feature.State.self
       """
     )
+
+    dump = ""
+    customDump((x: Double, y: Double).self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      (x: Double, y: Double).self
+      """
+    )
   }
 
   func testClass() {

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -24,6 +24,18 @@ final class DumpTests: XCTestCase {
       Foo.Bar.self
       """
     )
+
+    struct Feature {
+      struct State {}
+    }
+    dump = ""
+    customDump(Feature.State.self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      DumpTests.Feature.State.self
+      """
+    )
   }
 
   func testClass() {


### PR DESCRIPTION
The regular expression that strips excessive info from type names was refactored in #73 to fix some bugs that were discovered, but this change caused a regression in some nested types.