### PR TITLE
Abbreviate optional, array, and dictionary types

### DIFF
--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -9,11 +9,31 @@ func typeName(
       with: "",
       options: .regularExpression
     )
-    .replacingOccurrences(
-      of: #"\w+\.([\w.]+)"#,
-      with: "$1",
-      options: .regularExpression
-    )
+  for _ in 1...10 {  // NB: Only handle so much nesting
+    let abbreviated = name
+      .replacingOccurrences(
+        of: #"\bSwift.Optional<([^><]+)>"#,
+        with: "$1?",
+        options: .regularExpression
+      )
+      .replacingOccurrences(
+        of: #"\bSwift.Array<([^><]+)>"#,
+        with: "[$1]",
+        options: .regularExpression
+      )
+      .replacingOccurrences(
+        of: #"\bSwift.Dictionary<([^,<]+), ([^><]+)>"#,
+        with: "[$1: $2]",
+        options: .regularExpression
+      )
+    if abbreviated == name { break }
+    name = abbreviated
+  }
+  name = name.replacingOccurrences(
+    of: #"\w+\.([\w.]+)"#,
+    with: "$1",
+    options: .regularExpression
+  )
   if genericsAbbreviated {
     name = name.replacingOccurrences(
       of: #"<.+>"#,

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -45,6 +45,87 @@ final class DumpTests: XCTestCase {
       (x: Double, y: Double).self
       """
     )
+
+    dump = ""
+    customDump(Double?.self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      Double?.self
+      """
+    )
+
+    dump = ""
+    customDump([Int].self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [Int].self
+      """
+    )
+
+    dump = ""
+    customDump([String: Int].self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [String: Int].self
+      """
+    )
+
+    dump = ""
+    customDump([[Double: Double?]].self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [[Double: Double?]].self
+      """
+    )
+
+    dump = ""
+    customDump([[Double: Double]?].self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [[Double: Double]?].self
+      """
+    )
+
+    dump = ""
+    customDump([[Double: [Double]]]?.self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [[Double: [Double]]]?.self
+      """
+    )
+
+    dump = ""
+    customDump([[[Double: Double]]]?.self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [[[Double: Double]]]?.self
+      """
+    )
+
+    dump = ""
+    customDump([Double: [Double?]].self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [Double: [Double?]].self
+      """
+    )
+
+    dump = ""
+    customDump([Double: [Double]?].self, to: &dump)
+    XCTAssertNoDifference(
+      dump,
+      """
+      [Double: [Double]?].self
+      """
+    )
   }
 
   func testClass() {


### PR DESCRIPTION
We try our best to pretty-print in a Swift-y fashion, so let's extend that to the shorthand syntaxes for optionals, arrays, and dictionaries.