### PR TITLE
Add `String.init(customDumping:)`

### DIFF
--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -36,6 +36,15 @@ public func customDump<T>(
   return value
 }
 
+extension String {
+  /// Creates a string dumping the given value.
+  public init<Subject>(customDumping subject: Subject) {
+    var dump = ""
+    customDump(subject, to: &dump)
+    self = dump
+  }
+}
+
 /// Dumps the given value's contents using its mirror to the specified output stream.
 ///
 /// - Parameters:

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -16,10 +16,8 @@ import XCTest
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class DumpTests: XCTestCase {
   func testAnyType() {
-    var dump = ""
-    customDump(Foo.Bar.self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: Foo.Bar.self),
       """
       Foo.Bar.self
       """
@@ -28,100 +26,78 @@ final class DumpTests: XCTestCase {
     struct Feature {
       struct State {}
     }
-    dump = ""
-    customDump(Feature.State.self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: Feature.State.self),
       """
       DumpTests.Feature.State.self
       """
     )
 
-    dump = ""
-    customDump((x: Double, y: Double).self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: (x: Double, y: Double).self),
       """
       (x: Double, y: Double).self
       """
     )
 
-    dump = ""
-    customDump(Double?.self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: Double?.self),
       """
       Double?.self
       """
     )
 
-    dump = ""
-    customDump([Int].self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [Int].self),
       """
       [Int].self
       """
     )
 
-    dump = ""
-    customDump([String: Int].self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [String: Int].self),
       """
       [String: Int].self
       """
     )
 
-    dump = ""
-    customDump([[Double: Double?]].self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [[Double: Double?]].self),
       """
       [[Double: Double?]].self
       """
     )
 
-    dump = ""
-    customDump([[Double: Double]?].self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [[Double: Double]?].self),
       """
       [[Double: Double]?].self
       """
     )
 
-    dump = ""
-    customDump([[Double: [Double]]]?.self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [[Double: [Double]]]?.self),
       """
       [[Double: [Double]]]?.self
       """
     )
 
-    dump = ""
-    customDump([[[Double: Double]]]?.self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [[[Double: Double]]]?.self),
       """
       [[[Double: Double]]]?.self
       """
     )
 
-    dump = ""
-    customDump([Double: [Double?]].self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [[Double: [Double?]]]?.self),
       """
       [Double: [Double?]].self
       """
     )
 
-    dump = ""
-    customDump([Double: [Double]?].self, to: &dump)
     XCTAssertNoDifference(
-      dump,
+      String(customDumping: [Double: [Double]?]?.self),
       """
       [Double: [Double]?].self
       """

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -90,14 +90,14 @@ final class DumpTests: XCTestCase {
     )
 
     XCTAssertNoDifference(
-      String(customDumping: [[Double: [Double?]]]?.self),
+      String(customDumping: [Double: [Double?]].self),
       """
       [Double: [Double?]].self
       """
     )
 
     XCTAssertNoDifference(
-      String(customDumping: [Double: [Double]?]?.self),
+      String(customDumping: [Double: [Double]?].self),
       """
       [Double: [Double]?].self
       """


### PR DESCRIPTION
It can be useful to get a custom dump representation of a value as a string on a single line. Swift provides `String.init(describing:)` and `String.init(reflecting:)` (though no equivalent for a quick string from `Swift.dump`), so maybe we can provide _similar_ functionality via a string initializer.