### PR TITLE
Support ordered dictionaries/sets

### DIFF
--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -390,17 +390,19 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           }
           return lhs.key == rhs.key
         },
-        areInIncreasingOrder: {
+        areInIncreasingOrder: T.self is _UnorderedCollection.Type
+        ? {
           guard
             let lhs = $0.value as? (key: AnyHashable, value: Any),
             let rhs = $1.value as? (key: AnyHashable, value: Any)
           else {
             return _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
-              < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
+            < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
           }
           return _customDump(lhs.key.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
-            < _customDump(rhs.key.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
+          < _customDump(rhs.key.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
         }
+        : nil
       ) { child, _ in
         guard let pair = child.value as? (key: AnyHashable, value: Any) else { return }
         child = (
@@ -479,10 +481,12 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
         areEquivalent: {
           isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
         },
-        areInIncreasingOrder: {
+        areInIncreasingOrder: T.self is _UnorderedCollection.Type
+        ? {
           _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
             < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
         }
+        : nil
       )
 
     case (_, .struct?, _, .struct?):

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -209,7 +209,8 @@ func _customDump<T, TargetStream>(
         dumpChildren(
           of: mirror,
           prefix: "[", suffix: "]",
-          by: {
+          by: T.self is _UnorderedCollection.Type
+          ? {
             guard
               let (lhsKey, _) = $0.value as? (key: AnyHashable, value: Any),
               let (rhsKey, _) = $1.value as? (key: AnyHashable, value: Any)
@@ -217,7 +218,8 @@ func _customDump<T, TargetStream>(
 
             return _customDump(lhsKey.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
               < _customDump(rhsKey.base, name: nil, indent: 0, isRoot: false, maxDepth: 1)
-          },
+          }
+          : nil,
           { child, _ in
             guard let pair = child.value as? (key: AnyHashable, value: Any) else { return }
             let key = _customDump(
@@ -260,10 +262,13 @@ func _customDump<T, TargetStream>(
       dumpChildren(
         of: mirror,
         prefix: "Set([", suffix: "])",
-        by: {
+        by: T.self is _UnorderedCollection.Type
+        ? {
           _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
             < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
-        })
+        }
+        : nil
+      )
 
     case (_, .struct?):
       dumpChildren(of: mirror, prefix: "\(typeName(mirror.subjectType))(", suffix: ")")

--- a/Sources/CustomDump/Internal/Unordered.swift
+++ b/Sources/CustomDump/Internal/Unordered.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol _UnorderedCollection {}
+extension Dictionary: _UnorderedCollection {}
+extension NSDictionary: _UnorderedCollection {}
+extension NSSet: _UnorderedCollection {}
+extension Set: _UnorderedCollection {}

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -239,6 +239,100 @@ final class DiffTests: XCTestCase {
         ]
       """
     )
+
+    XCTAssertNoDifference(
+      diff(
+        OrderedDictionary(pairs: [
+          1: User(
+            id: 1,
+            name: "Blob"
+          ),
+          2: User(
+            id: 2,
+            name: "Blob, Jr."
+          ),
+        ]),
+        OrderedDictionary(pairs: [
+          1: User(
+            id: 1,
+            name: "Blob"
+          ),
+          2: User(
+            id: 2,
+            name: "Blob, Sr."
+          ),
+          3: User(
+            id: 3,
+            name: "Dr. Blob"
+          ),
+        ])
+      ),
+      """
+        [
+          1: User(…),
+          2: User(
+            id: 2,
+      -     name: "Blob, Jr."
+      +     name: "Blob, Sr."
+          ),
+      +   3: User(
+      +     id: 3,
+      +     name: "Dr. Blob"
+      +   )
+        ]
+      """
+    )
+
+    XCTAssertNoDifference(
+      diff(
+        OrderedDictionary(pairs: [
+          0: User(
+            id: 0,
+            name: "Original Blob"
+          ),
+          1: User(
+            id: 1,
+            name: "Blob"
+          ),
+          2: User(
+            id: 2,
+            name: "Blob, Jr."
+          ),
+        ]),
+        OrderedDictionary(pairs: [
+          0: User(
+            id: 0,
+            name: "Original Blob"
+          ),
+          1: User(
+            id: 1,
+            name: "Blob"
+          ),
+          2: User(
+            id: 2,
+            name: "Blob, Sr."
+          ),
+          3: User(
+            id: 3,
+            name: "Dr. Blob"
+          ),
+        ])
+      ),
+      """
+        [
+          … (2 unchanged),
+          2: User(
+            id: 2,
+      -     name: "Blob, Jr."
+      +     name: "Blob, Sr."
+          ),
+      +   3: User(
+      +     id: 3,
+      +     name: "Dr. Blob"
+      +   )
+        ]
+      """
+    )
   }
 
   func testDictionaryCollapsing() {

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -267,6 +267,37 @@ final class DumpTests: XCTestCase {
       ]
       """
     )
+
+    dump = ""
+    customDump(
+      OrderedDictionary(pairs: [
+        2: User(
+          id: 2,
+          name: "Blob, Jr."
+        ),
+        1: User(
+          id: 1,
+          name: "Blob"
+        ),
+      ] as KeyValuePairs),
+      to: &dump
+    )
+    XCTAssertNoDifference(
+      dump,
+      """
+      [
+        2: User(
+          id: 2,
+          name: "Blob, Jr."
+        ),
+        1: User(
+          id: 1,
+          name: "Blob"
+        )
+      ]
+      """
+    )
+
   }
 
   func testEnum() {

--- a/Tests/CustomDumpTests/Mocks.swift
+++ b/Tests/CustomDumpTests/Mocks.swift
@@ -139,3 +139,11 @@ struct Wrapped<Value> {
 struct Item {
   @Wrapped var isInStock = true
 }
+
+struct OrderedDictionary<Key, Value>: CustomReflectable {
+  var pairs: KeyValuePairs<Key, Value>
+
+  var customMirror: Mirror {
+    Mirror(self.pairs, unlabeledChildren: self.pairs, displayStyle: .dictionary)
+  }
+}


### PR DESCRIPTION
We currently auto-sort the children of any mirror with a display style of dictionary or set alphabetically. This is important for consistent dumps (good for snapshot tests, too), but affects types that don't need the sorting, like ordered dictionaries and sets.

This PR introduces an `_UnorderedCollection` protocol to control this behavior, and conforms `Dictionary`, `Set`, and their `NS`- predecessors, but leaves other types open to dumping and diffing in an ordered way by default.