### PR TITLE
Fix `CustomDumpRepresentable` max depth

### DIFF
--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -165,7 +165,7 @@ func _customDump<T, TargetStream>(
 
     case let (value as CustomDumpRepresentable, _):
       customDumpHelp(
-        value.customDumpValue, to: &out, name: nil, indent: 0, isRoot: false, maxDepth: maxDepth - 1
+        value.customDumpValue, to: &out, name: nil, indent: 0, isRoot: false, maxDepth: maxDepth
       )
 
     case let (value as AnyObject, .class?):

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -118,7 +118,7 @@ func _customDump<T, TargetStream>(
             maxDepth: maxDepth - 1
           )
           if childOut.contains("\n") {
-            if maxDepth == 0 {
+            if maxDepth <= 0 {
               out.write("…")
             } else {
               out.write("\n")
@@ -128,7 +128,7 @@ func _customDump<T, TargetStream>(
           } else {
             out.write(childOut)
           }
-        } else if maxDepth == 0 {
+        } else if maxDepth <= 0 {
           out.write("…")
         } else {
           out.write("\n")
@@ -287,7 +287,7 @@ func _customDump<T, TargetStream>(
     default:
       if let value = stringFromStringProtocol(value) {
         if value.contains(where: \.isNewline) {
-          if maxDepth == 0 {
+          if maxDepth <= 0 {
             out.write("\"…\"")
           } else {
             let hashes = String(repeating: "#", count: value.hashCount(isMultiline: true))

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -103,11 +103,11 @@ final class DiffTests: XCTestCase {
       diff(
         User(),
         User()
-      )?.replacingOccurrences(of: "0x[[:xdigit:]]+", with: "…", options: .regularExpression),
+      )?.replacingOccurrences(of: "0x[[:xdigit:]]+", with: "0x…", options: .regularExpression),
       """
         DiffTests.User(
-      -   _: ObjectIdentifier(…),
-      +   _: ObjectIdentifier(…),
+      -   _: ObjectIdentifier(0x…),
+      +   _: ObjectIdentifier(0x…),
           id: 42,
           name: "Blob"
         )
@@ -441,6 +441,29 @@ final class DiffTests: XCTestCase {
           1,
       -   .foo
       +   .buzz
+        )
+      """
+    )
+  }
+
+  func testEnumCollapsing() {
+    enum Offset: Equatable {
+      case page(Int, perPage: Int = 10)
+    }
+    struct State: Equatable {
+      var offset: Offset
+      let result: String
+    }
+    XCTAssertNoDifference(
+      diff(
+        State(offset: .page(1), result: "Hello, world!"),
+        State(offset: .page(1), result: "Good night, moon!")
+      ),
+      """
+        DiffTests.State(
+          offset: .page(…),
+      -   result: "Hello, world!"
+      +   result: "Good night, moon!"
         )
       """
     )

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -1111,6 +1111,31 @@ final class DiffTests: XCTestCase {
       """
     )
   }
+
+  func testCustomDumpRepresentableCollapsing() {
+    struct Results: CustomDumpRepresentable, Equatable {
+      var customDumpValue: Any {
+        [1, 2]
+      }
+    }
+    struct State: Equatable {
+      var date: Double
+      var results: Results
+    }
+    XCTAssertNoDifference(
+      diff(
+        State(date: 123456789, results: Results()),
+        State(date: 123456790, results: Results())
+      ),
+      """
+        DiffTests.State(
+      -   date: 123456789.0,
+      +   date: 123456790.0,
+          results: […]
+        )
+      """
+    )
+  }
 }
 
 private struct Stack<State: Equatable>: CustomDumpReflectable, Equatable {


### PR DESCRIPTION
When we reach a custom dump representable value, we should not decrement the max depth when printing it, and instead we should pass the current configuration through.

The current behavior can cause the max depth to roll from 0 to -1, which currently causes the logic that collapses nodes to leave them expanded.

We should update that logic, as well, to collapse whenever <= 0, so I'll do that in another commit.