### PR TITLE
Sort unordered dictionaries when nested in another type

### DIFF
--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -392,7 +392,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           }
           return lhs.key == rhs.key
         },
-        areInIncreasingOrder: T.self is _UnorderedCollection.Type
+        areInIncreasingOrder: lhsMirror.subjectType is _UnorderedCollection.Type
           ? {
             guard
               let lhs = $0.value as? (key: AnyHashable, value: Any),
@@ -483,7 +483,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
         areEquivalent: {
           isIdentityEqual($0.value, $1.value) || isMirrorEqual($0.value, $1.value)
         },
-        areInIncreasingOrder: T.self is _UnorderedCollection.Type
+        areInIncreasingOrder: lhsMirror.subjectType is _UnorderedCollection.Type
           ? {
             _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
               < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -209,7 +209,7 @@ func _customDump<T, TargetStream>(
         dumpChildren(
           of: mirror,
           prefix: "[", suffix: "]",
-          by: T.self is _UnorderedCollection.Type
+          by: mirror.subjectType is _UnorderedCollection.Type
             ? {
               guard
                 let (lhsKey, _) = $0.value as? (key: AnyHashable, value: Any),
@@ -262,7 +262,7 @@ func _customDump<T, TargetStream>(
       dumpChildren(
         of: mirror,
         prefix: "Set([", suffix: "])",
-        by: T.self is _UnorderedCollection.Type
+        by: mirror.subjectType is _UnorderedCollection.Type
           ? {
             _customDump($0.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)
               < _customDump($1.value, name: nil, indent: 0, isRoot: false, maxDepth: 1)

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -298,7 +298,31 @@ final class DumpTests: XCTestCase {
       ]
       """
     )
+  }
 
+  func testDictionary_Nested() {
+    struct NestedDictionary {
+      let content: [String: Int]
+    }
+
+    XCTAssertNoDifference(
+      """
+      DumpTests.NestedDictionary(
+        content: [
+          "a": 5,
+          "b": 9,
+          "c": 1,
+          "d": -3,
+          "e": 12
+        ]
+      )
+      """,
+      String(
+        customDumping: NestedDictionary(
+          content: ["a": 5, "b": 9, "c": 1, "d": -3, "e": 12]
+        )
+      )
+    )
   }
 
   func testEnum() {


### PR DESCRIPTION
Fixes #87.

The generic `T` is `Any` when traversing deeper into the mirror. It's possible that we should be opening existentials more explicitly at each layer, but we already have the mirror's subject type, so we can use that instead.