### PR TITLE
Fix crash when diffing LocalizedStringKey with FormatStyle

### DIFF
--- a/Sources/CustomDump/Conformances/SwiftUI.swift
+++ b/Sources/CustomDump/Conformances/SwiftUI.swift
@@ -51,17 +51,14 @@
       let arguments: [CVarArg] = Array(Mirror(reflecting: children[2].value).children)
         .compactMap {
           let children = Array(Mirror(reflecting: $0.value).children)
-          let value: Any
-          let formatter: Formatter?
           // `LocalizedStringKey.FormatArgument` differs depending on OS/platform.
           if children[0].label == "storage" {
-            (value, formatter) =
-              Array(Mirror(reflecting: children[0].value).children)[0].value as! (Any, Formatter?)
+            return formattedArgumentFromStorage(children[0])
           } else {
-            value = children[0].value
-            formatter = children[1].value as? Formatter
+            let value = children[0].value
+            let formatter = children[1].value as? Formatter
+            return formatter?.string(for: value) ?? value as! CVarArg
           }
-          return formatter?.string(for: value) ?? value as! CVarArg
         }
 
       let format = NSLocalizedString(
@@ -72,6 +69,26 @@
         comment: comment.map(String.init) ?? ""
       )
       return String(format: format, locale: locale, arguments: arguments)
+    }
+
+    private func formattedArgumentFromStorage(_ storage: Mirror.Child) -> CVarArg {
+      let storage = Array(Mirror(reflecting: storage.value).children)[0].value
+
+      // Check if storage is a FormatStyle
+      if #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) {
+        let formatStyleBoxChildren = Array(Mirror(reflecting: storage).children)
+        if formatStyleBoxChildren.count == 2, let formatStyle = formatStyleBoxChildren[1].value as? (any FormatStyle) {
+          func formatValue<S: FormatStyle>(style: S, input: Any) -> String {
+            let input = input as! S.FormatInput
+            return style.format(input) as! String
+          }
+          return formatValue(style: formatStyle, input: formatStyleBoxChildren[0].value)
+        }
+      }
+
+      // Fallback to Formatter
+      let (value, formatter) = storage as! (Any, Formatter?)
+      return formatter?.string(for: value) ?? value as! CVarArg
     }
   }
 #endif

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -1,5 +1,8 @@
 import CustomDump
 import XCTest
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class DiffTests: XCTestCase {
@@ -1087,6 +1090,46 @@ final class DiffTests: XCTestCase {
       """
     )
   }
+
+#if canImport(SwiftUI)
+  @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+  func testLocalizedStringKey() {
+    XCTAssertNoDifference(
+      diff(
+        "My name is Jack" as LocalizedStringKey,
+        "My name is Jill" as LocalizedStringKey
+      ),
+      """
+      - "My name is Jack"
+      + "My name is Jill"
+      """
+    )
+
+    let name1 = "Jack"
+    let name2 = "Jill"
+    XCTAssertNoDifference(
+      diff(
+        "My name is \(name1)" as LocalizedStringKey,
+        "My name is \(name2)" as LocalizedStringKey
+      ),
+      """
+      - "My name is Jack"
+      + "My name is Jill"
+      """
+    )
+
+    XCTAssertNoDifference(
+      diff(
+        "Time remaining: \(Duration.seconds(10), format: .time(pattern: .minuteSecond))" as LocalizedStringKey,
+        "Time remaining: \(Duration.seconds(9), format: .time(pattern: .minuteSecond))" as LocalizedStringKey
+      ),
+      """
+      - "Time remaining: 0:10"
+      + "Time remaining: 0:09"
+      """
+    )
+  }
+#endif
 
   func testCustomDictionary() {
     XCTAssertEqual(


### PR DESCRIPTION
This is a partial fix for #97. This fix covers the cases where an interpolation was appended using [`appendInterpolation(_:format:)`](https://developer.apple.com/documentation/swiftui/localizedstringkey/stringinterpolation/appendinterpolation(_:format:)) but does not cover the other cases mentioned in the issue.

I attempted to fix the others as well and was able to unwrap a `(Date, Text.DateStyle)`, but there doesn't seem to be a publicly-accessible way to use the DateStyle to format the date. Here is a gist that demonstrates unwrapping the DateStyle:
https://gist.github.com/daltonclaybrook/5491f296d9d5806dd31f4d777aea347f
