### PR TITLE
Turn Windows CI back on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,20 @@ jobs:
         with:
           shell-action: carton test --environment node
 
-  #windows:
-  #  name: Windows
-  #  runs-on: windows-latest
-  #  steps:
-  #    - uses: compnerd/gha-setup-swift@main
-  #      with:
-  #        branch: swift-5.7-release
-  #        tag: 5.7.1-RELEASE
-  #
-  #    - uses: actions/checkout@v3
-  #    - run: swift test && swift build --configuration release
+  windows:
+    name: Windows
+    strategy:
+      matrix:
+        os: [windows-latest]
+        config: ['debug', 'release']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8.1-release
+          tag: 5.8.1-RELEASE
+      - uses: actions/checkout@v3
+      - name: Build All Configurations
+        run: swift build -c ${{ matrix.config }}
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,5 +92,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build All Configurations
         run: swift build -c ${{ matrix.config }}
-      - name: Run tests
+      - name: Run tests (debug only)
+        # There is an issue that exists in the 5.8.1 toolchain
+        # which fails on release configuration testing, but
+        # this issue is fixed 5.9 so we can remove the if once
+        # that is generally available.
+        if: ${{ matrix.config == 'debug' }}
         run: swift test


### PR DESCRIPTION
We want to start running Windows CI to ensure that no breakage happens on the Windows platform.