### PR TITLE
Filter properties prefixed with `_$`

### DIFF
--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -1159,6 +1159,28 @@ final class DiffTests: XCTestCase {
       """
     )
   }
+
+  func testObservationRegistrarFiltered() {
+    struct ObservationRegistrar: Equatable {}
+    struct Value: Equatable {
+      var name: String
+      let _$observationRegistrar = ObservationRegistrar()
+    }
+    let blobSr = Value(name: "Blob Sr.")
+    let blobJr = Value(name: "Blob Jr.")
+    XCTAssertNoDifference(
+      diff(
+        blobSr,
+        blobJr
+      ),
+      """
+        DiffTests.Value(
+      -   name: "Blob Sr."
+      +   name: "Blob Jr."
+        )
+      """
+    )
+  }
 }
 
 private struct Stack<State: Equatable>: CustomDumpReflectable, Equatable {

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -1301,4 +1301,32 @@ final class DumpTests: XCTestCase {
       )
     }
   #endif
+
+  func testObservationRegistrarFiltered() {
+    struct ObservationRegistrar {}
+    class Object {
+      let name = "Blob Sr."
+      let _$observationRegistrar = ObservationRegistrar()
+    }
+    XCTAssertNoDifference(
+      String(customDumping: Object()),
+      """
+      DumpTests.Object(
+        name: "Blob Sr."
+      )
+      """
+    )
+    struct Value {
+      let name = "Blob Jr."
+      let _$observationRegistrar = ObservationRegistrar()
+    }
+    XCTAssertNoDifference(
+      String(customDumping: Value()),
+      """
+      DumpTests.Value(
+        name: "Blob Jr."
+      )
+      """
+    )
+  }
 }


### PR DESCRIPTION
This seems to be the macro convention, and as folks add `@Observable` to their types they will begin to see these details leaking into their dumps, which is generally not relevant and doesn't result in a dump that resembles the original source.

We could consider a configuration option in the future to dump these values, but for now folks can always use plain `dump` or a mirror to access these values when they need them.