### PR TITLE
Update for visionOS beta 6

### DIFF
--- a/Sources/CustomDump/Conformances/CoreLocation.swift
+++ b/Sources/CustomDump/Conformances/CoreLocation.swift
@@ -81,7 +81,7 @@
     @available(iOS 7, macOS 10.15, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    @available(xrOS, unavailable)
+    @available(visionOS, unavailable)
     extension CLProximity: CustomDumpStringConvertible {
       public var customDumpDescription: String {
         switch self {
@@ -124,7 +124,7 @@
     @available(iOS 7, macOS 10, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    @available(xrOS, unavailable)
+    @available(visionOS, unavailable)
     extension CLRegionState: CustomDumpStringConvertible {
       public var customDumpDescription: String {
         switch self {


### PR DESCRIPTION
`xrOS` no longer gates for availability checks as of visionOS 1.0 beta 6. This PR replaces it with the new os name: `visionOS`