### PR TITLE
Add experimental support for "diffable" objects

### DIFF
--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -397,8 +397,7 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           terminator: "",
           to: &out
         )
-      } else if lhsItem == rhsItem,
-        let (lhs, rhs) = (lhs as? any _CustomDiffObject)?._customDiffValues
+      } else if lhsItem == rhsItem, let (lhs, rhs) = (lhs as? _CustomDiffObject)?._customDiffValues
       {
         print(
           diffHelp(

--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -397,7 +397,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           terminator: "",
           to: &out
         )
-      } else if lhsItem == rhsItem, let (lhs, rhs) = (lhs as? _CustomDiffObject)?._customDiffValues
+      } else if lhsItem == rhsItem,
+        let (lhs, rhs) = (lhs as? _CustomDiffObject)?._customDiffValues
       {
         print(
           diffHelp(

--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -339,6 +339,22 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           terminator: "",
           to: &out
         )
+      } else if lhsItem == rhsItem,
+        let (lhs, rhs) = (lhs as? any _CustomDiffObject)?._customDiffValues
+      {
+        print(
+          diffHelp(
+            lhs,
+            rhs,
+            lhsName: lhsName,
+            rhsName: rhsName,
+            separator: separator,
+            indent: indent,
+            isRoot: isRoot
+          ),
+          terminator: "",
+          to: &out
+        )
       } else {
         let showObjectIdentifiers =
           lhsItem != rhsItem
@@ -635,4 +651,8 @@ private struct Line: CustomDumpStringConvertible, Identifiable {
   var customDumpDescription: String {
     .init(self.rawValue)
   }
+}
+
+public protocol _CustomDiffObject: AnyObject {
+  var _customDiffValues: (Any, Any) { get }
 }

--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -326,9 +326,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
           terminator: "",
           to: &out
         )
-      } else if lhsItem == rhsItem,
-        let (lhs, rhs) = (lhs as? any _CustomDiffObject)?._customDiffValues
-      {
+      } else if lhsItem == rhsItem {
+        let (lhs, rhs) = lhs._customDiffValues
         print(
           diffHelp(
             lhs,

--- a/Sources/CustomDump/Internal/Mirror.swift
+++ b/Sources/CustomDump/Internal/Mirror.swift
@@ -9,8 +9,14 @@ extension Mirror {
         let child = self.children.first
       else { return false }
       var value = child.value
+      if value is _CustomDiffObject {
+        return false
+      }
       while let representable = value as? CustomDumpRepresentable {
         value = representable.customDumpValue
+        if value is _CustomDiffObject {
+          return false
+        }
       }
       if let convertible = child.value as? CustomDumpStringConvertible {
         return !convertible.customDumpDescription.contains("\n")

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -1183,40 +1183,42 @@ final class DiffTests: XCTestCase {
   }
 
   func testDiffableObject() {
-    class Foo: _CustomDiffObject, Equatable {
-      var _customDiffValues: (Any, Any) {
-        ("before", "after")
-      }
-      static func == (lhs: Foo, rhs: Foo) -> Bool {
-        false
-      }
-    }
-    let foo = Foo()
+    let obj = DiffableObject()
     XCTAssertNoDifference(
-      diff(foo, foo),
+      diff(obj, obj),
       """
       - "before"
       + "after"
       """
     )
 
-    struct Bar: Equatable {
-      var foo1: Foo
-      var foo2: Foo
-    }
-    let bar = Bar(foo1: foo, foo2: foo)
+    let bar = DiffableObjects(obj1: obj, obj2: obj)
     XCTAssertNoDifference(
       diff(bar, bar),
       """
-        DiffTests.Bar(
-      -   foo1: "before",
-      +   foo1: "after",
-      -   foo2: "before"
-      +   foo2: "after"
+        DiffableObjects(
+      -   obj1: "before",
+      +   obj1: "after",
+      -   obj2: "before"
+      +   obj2: "after"
         )
       """
     )
   }
+}
+
+private class DiffableObject: _CustomDiffObject, Equatable {
+  var _customDiffValues: (Any, Any) {
+    ("before", "after")
+  }
+  static func == (lhs: DiffableObject, rhs: DiffableObject) -> Bool {
+    false
+  }
+}
+
+private struct DiffableObjects: Equatable {
+  var obj1: DiffableObject
+  var obj2: DiffableObject
 }
 
 private struct Stack<State: Equatable>: CustomDumpReflectable, Equatable {

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -1181,6 +1181,42 @@ final class DiffTests: XCTestCase {
       """
     )
   }
+
+  func testDiffableObject() {
+    class Foo: _CustomDiffObject, Equatable {
+      var _customDiffValues: (Any, Any) {
+        ("before", "after")
+      }
+      static func == (lhs: Foo, rhs: Foo) -> Bool {
+        false
+      }
+    }
+    let foo = Foo()
+    XCTAssertNoDifference(
+      diff(foo, foo),
+      """
+      - "before"
+      + "after"
+      """
+    )
+
+    struct Bar: Equatable {
+      var foo1: Foo
+      var foo2: Foo
+    }
+    let bar = Bar(foo1: foo, foo2: foo)
+    XCTAssertNoDifference(
+      diff(bar, bar),
+      """
+        DiffTests.Bar(
+      -   foo1: "before",
+      +   foo1: "after",
+      -   foo2: "before"
+      +   foo2: "after"
+        )
+      """
+    )
+  }
 }
 
 private struct Stack<State: Equatable>: CustomDumpReflectable, Equatable {


### PR DESCRIPTION
Object references aren't copyable, so objects aren't "diffable" by default. This PR adds experimental support for objects that can be diffed by allowing them to describe the difference.