### PR TITLE
Fix Xcode 15.3 Release Crash

### DIFF
--- a/Sources/CustomDump/Conformances/KeyPath.swift
+++ b/Sources/CustomDump/Conformances/KeyPath.swift
@@ -8,7 +8,7 @@ extension AnyKeyPath: CustomDumpStringConvertible {
         return self.debugDescription
       }
     #endif
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    #if DEBUG && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
       keyPathToNameLock.lock()
       defer { keyPathToNameLock.unlock() }
 
@@ -49,7 +49,7 @@ extension AnyKeyPath: CustomDumpStringConvertible {
   }
 }
 
-#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+#if DEBUG && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
   private var keyPathToNameLock = NSRecursiveLock()
   private var keyPathToName: [AnyKeyPath: String] = [:]
 


### PR DESCRIPTION
A SIL function we load seems to be unavailable, so let's limit old key path printing to DEBUG builds.

Fixes #107.