### PR TITLE
Use `swiftwasm/setup-swiftwasm` instead of `swiftwasm/swiftwasm-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: bytecodealliance/actions/wasmtime/setup@v1
       - uses: swiftwasm/setup-swiftwasm@v1
         with:
-          swift-version: "wasm-5.8.0-RELEASE"
+          swift-version: "wasm-5.9.2-RELEASE"
       - name: Build tests
         run: swift build --triple wasm32-unknown-wasi --build-tests
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: swiftwasm/swiftwasm-action@v5.8
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
+      - uses: swiftwasm/setup-swiftwasm@v1
         with:
-          shell-action: carton test --environment node
+          swift-version: "wasm-5.8.0-RELEASE"
+      - name: Build tests
+        run: swift build --triple wasm32-unknown-wasi --build-tests
+      - name: Run tests
+        run: wasmtime .build/debug/swift-custom-dumpPackageTests.wasm
 
   windows:
     name: Windows


### PR DESCRIPTION
`swiftwasm/swiftwasm-action` is now deprecated and replaced by `swiftwasm/setup-swiftwasm`. This change updates the CI workflow to use the new action.