### PR TITLE
Expose `typeName` function via `@_spi`

### DIFF
--- a/Sources/CustomDump/Internal/AnyType.swift
+++ b/Sources/CustomDump/Internal/AnyType.swift
@@ -1,4 +1,4 @@
-func typeName(
+@_spi(TypeName) public func typeName(
   _ type: Any.Type,
   qualified: Bool = true,
   genericsAbbreviated: Bool = true


### PR DESCRIPTION
We have this function copied and pasted a few places now, and I wanted it elsewhere. I'm not sure what a public interface should look like, since it mimics Swift's own `_typeName` function, but for now we could just use SPI.