### PR TITLE
Turn on Swift 6 language mode.

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -32,5 +32,6 @@ let package = Package(
         "CustomDump"
       ]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v6]
 )

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -32,16 +32,11 @@ extension Calendar: CustomDumpReflectable {
 }
 
 #if !os(WASI)
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension Data: CustomDumpStringConvertible {
     public var customDumpDescription: String {
-      "Data(\(Self.formatter.string(fromByteCount: .init(self.count))))"
+      "Data\(self.count.formatted(.byteCount(style: .memory)))"
     }
-
-    private static let formatter: ByteCountFormatter = {
-      let formatter = ByteCountFormatter()
-      formatter.allowedUnits = .useBytes
-      return formatter
-    }()
   }
 #endif
 

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -32,12 +32,20 @@ extension Calendar: CustomDumpReflectable {
 }
 
 #if !os(WASI)
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension Data: CustomDumpStringConvertible {
     public var customDumpDescription: String {
-      "Data\(self.count.formatted(.byteCount(style: .memory)))"
+      formatterLock.withLock {
+        "Data(\(Self.formatter.string(fromByteCount: .init(self.count))))"
+      }
     }
+
+    nonisolated(unsafe) private static let formatter: ByteCountFormatter = {
+      let formatter = ByteCountFormatter()
+      formatter.allowedUnits = .useBytes
+      return formatter
+    }()
   }
+  private let formatterLock = NSLock()
 #endif
 
 #if !os(WASI)


### PR DESCRIPTION
There was only one small thing stopping us from turning on Swift 6 mode in this package, and that was our use of a data bytes formatter. It may be OK to just `nonisolated(unsafe)` it since the initialization of static variables is thread safe in Swift _and_ since we never mutate the formatter after initialization. But I went ahead and wrapped it in a lock too just in case.

Alternatively we could use the new `FormatStyle` stuff, but then the `CustomDumpStringConvertible` conformance will be iOS 15+ (probably not a big deal), but also I don't think `FormatStyle` is implemented in corelibs-foundation.