### PR TITLE
Point Issue Reporting to xctest-dynamic-overlay repo

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "swift-issue-reporting",
+      "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "926f43898706eaa127db79ac42138e1ad7e85a3f",
-        "version" : "1.2.0"
+        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
+        "version" : "1.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,14 +17,14 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.2.0")
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2")
   ],
   targets: [
     .target(
       name: "CustomDump",
       dependencies: [
-        .product(name: "IssueReporting", package: "swift-issue-reporting"),
-        .product(name: "XCTestDynamicOverlay", package: "swift-issue-reporting"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency")

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -17,14 +17,14 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.2.0")
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2")
   ],
   targets: [
     .target(
       name: "CustomDump",
       dependencies: [
-        .product(name: "IssueReporting", package: "swift-issue-reporting"),
-        .product(name: "XCTestDynamicOverlay", package: "swift-issue-reporting"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
Swift Package Manager honors redirects, but it appears to associate the path suffix with the package name, and this conflicts with package resolution in certain (but not all) cases.

I think we have no choice but to roll back everything to point to the original xctest-dynamic-overlay URL and extract Issue Reporting to a dedicated repo.