### PR TITLE
Fix Swift 6 concurrency error (on Linux)

### DIFF
--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -47,12 +47,12 @@ extension Calendar: CustomDumpReflectable {
       "Date(\(Self.formatter.string(from: self)))"
     }
 
-    private static let formatter: DateFormatter = {
+    private static var formatter: DateFormatter {
       let formatter = DateFormatter()
       formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
       formatter.timeZone = TimeZone(secondsFromGMT: 0)!
       return formatter
-    }()
+    }
   }
 #endif
 


### PR DESCRIPTION
This fixes a Swift 6 compile error (on Linux):

```
/host/Sources/CustomDump/Conformances/Foundation.swift:50:24: error: static property 'formatter' is not concurrency-safe because non-'Sendable' type 'DateFormatter' may have shared mutable state
 48 |     }
 49 | 
 50 |     private static let formatter: DateFormatter = {
    |                        `- error: static property 'formatter' is not concurrency-safe because non-'Sendable' type 'DateFormatter' may have shared mutable state
 51 |       let formatter = DateFormatter()
 52 |       formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
```

See also: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3115#issuecomment-2153037172