### PR TITLE
Update Package.swift to Address Renamed Dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,9 @@
 // swift-tools-version: 5.9
 
+// ⚠️ This fork updates the dependency URL for the 'xctest-dynamic-overlay' repository, 
+// which appears to have been renamed to 'swift-issue-reporting'. 
+// This change addresses conflicts arising from this renaming.
+
 import PackageDescription
 
 let package = Package(
@@ -17,14 +21,14 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2")
+    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "1.2.2"),
   ],
   targets: [
     .target(
       name: "CustomDump",
       dependencies: [
-        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "swift-issue-reporting"),
+        .product(name: "XCTestDynamicOverlay", package: "swift-issue-reporting"),
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency")


### PR DESCRIPTION
This pull request updates the `Package.swift` file to address the renaming of the `xctest-dynamic-overlay` dependency to `swift-issue-reporting`. 

Specifically:

- The dependency URL has been updated from `https://github.com/pointfreeco/xctest-dynamic-overlay` to `https://github.com/pointfreeco/swift-issue-reporting`.

- The `.product` references within the `dependencies` and `targets` have been updated accordingly:

  - Updated: `.product(name: "IssueReporting", package: "xctest-dynamic-overlay")` to `.product(name: "IssueReporting", package: "swift-issue-reporting")`.
  - Updated `.product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay")` to `.product(name: "XCTestDynamicOverlay", package: "swift-issue-reporting")`.

These changes have allowed me to successfully build my projects when using my forked version.