### PR TITLE
Fix host thousands separator setting causing test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,24 +37,6 @@ jobs:
       - name: Run tests (platforms)
         run: make test-platforms
 
-  # linux:
-  #   name: Ubuntu
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       swift:
-  #         - '6.2.3'
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #     - name: Install Swift ${{ matrix.swift }}
-  #       uses: swift-actions/setup-swift@v3
-  #       with:
-  #         swift-version: ${{ matrix.swift }}
-  #     - name: Print Swift version
-  #       run: swift --version
-  #     - name: Run tests
-  #       run: make test-swift
-
   # wasm:
   #   name: Wasm
   #   runs-on: ubuntu-latest
@@ -72,3 +54,15 @@ jobs:
 
   #     - name: Build
   #       run: swift build --swift-sdk swift-6.2.3-RELEASE_wasm --target CustomDump -Xlinker -z -Xlinker stack-size=$((1024 * 1024))
+
+  linux-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Test Swift Package on Linux"
+        run: swift test
+      - name: "Test Swift Package on Android"
+        uses: skiptools/swift-android-action@v2
+        with:
+          # Ubuntu runners low on space causes the emulator to fail to install
+          free-disk-space: true

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -34,9 +34,16 @@ extension Calendar: CustomDumpReflectable {
 #if !os(WASI)
   extension Data: CustomDumpStringConvertible {
     public var customDumpDescription: String {
-      let formatter = ByteCountFormatter()
-      formatter.allowedUnits = .useBytes
-      return "Data(\(formatter.string(fromByteCount: .init(self.count))))"
+      let bytes = Self.numberFormatter.string(from: self.count as NSNumber) ?? "\(self.count)"
+      return "Data(\(bytes) \(self.count == 1 ? "byte" : "bytes"))"
+    }
+
+    private static var numberFormatter: NumberFormatter {
+      let formatter = NumberFormatter()
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.numberStyle = .decimal
+      formatter.usesGroupingSeparator = true
+      return formatter
     }
   }
 #endif

--- a/Tests/CustomDumpTests/Conformances/FoundationTests.swift
+++ b/Tests/CustomDumpTests/Conformances/FoundationTests.swift
@@ -183,6 +183,20 @@ final class FoundationTests: XCTestCase {
         """
       )
     }
+
+    func testNSDataLargeByteCount() {
+      var dump = ""
+      customDump(
+        NSData(data: .init(repeating: 0, count: 16_811)),
+        to: &dump
+      )
+      expectNoDifference(
+        dump,
+        """
+        Data(16,811 bytes)
+        """
+      )
+    }
   #endif
 
   #if !os(WASI)

--- a/Tests/CustomDumpTests/ExpectDifferenceTests.swift
+++ b/Tests/CustomDumpTests/ExpectDifferenceTests.swift
@@ -1,6 +1,8 @@
 import CustomDump
 import Testing
+import IssueReportingTestSupport
 
+#if !os(Android)
 struct ExpectDifferenceTests {
   @Test func basics() {
     var user = User(id: 42, name: "Blob")
@@ -53,3 +55,4 @@ struct ExpectDifferenceTests {
     }
   }
 }
+#endif

--- a/Tests/CustomDumpTests/ExpectDifferenceTests.swift
+++ b/Tests/CustomDumpTests/ExpectDifferenceTests.swift
@@ -1,58 +1,58 @@
 import CustomDump
-import Testing
 import IssueReportingTestSupport
+import Testing
 
 #if !os(Android)
-struct ExpectDifferenceTests {
-  @Test func basics() {
-    var user = User(id: 42, name: "Blob")
-    func increment<Value>(_ root: inout Value, at keyPath: WritableKeyPath<Value, Int>) {
-      root[keyPath: keyPath] += 1
-    }
+  struct ExpectDifferenceTests {
+    @Test func basics() {
+      var user = User(id: 42, name: "Blob")
+      func increment<Value>(_ root: inout Value, at keyPath: WritableKeyPath<Value, Int>) {
+        root[keyPath: keyPath] += 1
+      }
 
-    expectDifference(user) {
-      increment(&user, at: \.id)
-    } changes: {
-      $0.id = 43
-    }
-  }
-
-  @Test func nonExhaustive() {
-    var user = User(id: 42, name: "Blob")
-    user.id += 1
-    user.name += " Jr"
-    expectDifference(user) {
-      $0.name = "Blob Jr"
-    }
-  }
-
-  @Test func failure() {
-    var user = User(id: 42, name: "Blob")
-    func increment<Value>(_ root: inout Value, at keyPath: WritableKeyPath<Value, Int>) {
-      root[keyPath: keyPath] += 1
-    }
-
-    withKnownIssue {
       expectDifference(user) {
         increment(&user, at: \.id)
       } changes: {
-        $0.id = 44
+        $0.id = 43
       }
-    } matching: {
-      $0.description.hasSuffix(
-        """
-        Difference: …
+    }
 
-            User(
-          −   id: 44,
-          +   id: 43,
-              name: "Blob"
-            )
+    @Test func nonExhaustive() {
+      var user = User(id: 42, name: "Blob")
+      user.id += 1
+      user.name += " Jr"
+      expectDifference(user) {
+        $0.name = "Blob Jr"
+      }
+    }
 
-        (Expected: −, Actual: +)
-        """
-      )
+    @Test func failure() {
+      var user = User(id: 42, name: "Blob")
+      func increment<Value>(_ root: inout Value, at keyPath: WritableKeyPath<Value, Int>) {
+        root[keyPath: keyPath] += 1
+      }
+
+      withKnownIssue {
+        expectDifference(user) {
+          increment(&user, at: \.id)
+        } changes: {
+          $0.id = 44
+        }
+      } matching: {
+        $0.description.hasSuffix(
+          """
+          Difference: …
+
+              User(
+            −   id: 44,
+            +   id: 43,
+                name: "Blob"
+              )
+
+          (Expected: −, Actual: +)
+          """
+        )
+      }
     }
   }
-}
 #endif

--- a/Tests/CustomDumpTests/ExpectNoDifferenceTests.swift
+++ b/Tests/CustomDumpTests/ExpectNoDifferenceTests.swift
@@ -1,7 +1,9 @@
 import CustomDump
 import Foundation
 import Testing
+import IssueReportingTestSupport
 
+#if !os(Android)
 struct ExpectNoDifferenceTests {
   @Test func basics() {
     struct User: Equatable {
@@ -37,3 +39,4 @@ struct ExpectNoDifferenceTests {
     }
   }
 }
+#endif

--- a/Tests/CustomDumpTests/ExpectNoDifferenceTests.swift
+++ b/Tests/CustomDumpTests/ExpectNoDifferenceTests.swift
@@ -1,42 +1,42 @@
 import CustomDump
 import Foundation
-import Testing
 import IssueReportingTestSupport
+import Testing
 
 #if !os(Android)
-struct ExpectNoDifferenceTests {
-  @Test func basics() {
-    struct User: Equatable {
-      var id: UUID
-      var name: String
-      var bio: String
-    }
-    let user = User(
-      id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!,
-      name: "Blob",
-      bio: "Blobbed around the world."
-    )
-    var otherUser = user
-    expectNoDifference(user, otherUser)
-    otherUser.name += " Jr."
-    withKnownIssue {
-      expectNoDifference(user, otherUser)
-    } matching: {
-      $0.description.hasSuffix(
-        """
-        Difference: …
-
-            ExpectNoDifferenceTests.User(
-              id: UUID(DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF),
-          −   name: "Blob",
-          +   name: "Blob Jr.",
-              bio: "Blobbed around the world."
-            )
-
-        (First: −, Second: +)
-        """
+  struct ExpectNoDifferenceTests {
+    @Test func basics() {
+      struct User: Equatable {
+        var id: UUID
+        var name: String
+        var bio: String
+      }
+      let user = User(
+        id: UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF")!,
+        name: "Blob",
+        bio: "Blobbed around the world."
       )
+      var otherUser = user
+      expectNoDifference(user, otherUser)
+      otherUser.name += " Jr."
+      withKnownIssue {
+        expectNoDifference(user, otherUser)
+      } matching: {
+        $0.description.hasSuffix(
+          """
+          Difference: …
+
+              ExpectNoDifferenceTests.User(
+                id: UUID(DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF),
+            −   name: "Blob",
+            +   name: "Blob Jr.",
+                bio: "Blobbed around the world."
+              )
+
+          (First: −, Second: +)
+          """
+        )
+      }
     }
   }
-}
 #endif


### PR DESCRIPTION
Resolve issue where host settings for number formatting of thousands separator caused test failures.

Now tests comparing larger Data instances work also if your host setting differs from the original test implementation.