### PR TITLE
Resolve issue where host settings for number formatting of thousands separator caused test failures

### DIFF
--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -34,9 +34,16 @@ extension Calendar: CustomDumpReflectable {
 #if !os(WASI)
   extension Data: CustomDumpStringConvertible {
     public var customDumpDescription: String {
-      let formatter = ByteCountFormatter()
-      formatter.allowedUnits = .useBytes
-      return "Data(\(formatter.string(fromByteCount: .init(self.count))))"
+      let bytes = Self.numberFormatter.string(from: self.count as NSNumber) ?? "\(self.count)"
+      return "Data(\(bytes) \(self.count == 1 ? "byte" : "bytes"))"
+    }
+
+    private static var numberFormatter: NumberFormatter {
+      let formatter = NumberFormatter()
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.numberStyle = .decimal
+      formatter.usesGroupingSeparator = true
+      return formatter
     }
   }
 #endif

--- a/Tests/CustomDumpTests/Conformances/FoundationTests.swift
+++ b/Tests/CustomDumpTests/Conformances/FoundationTests.swift
@@ -183,6 +183,20 @@ final class FoundationTests: XCTestCase {
         """
       )
     }
+
+    func testNSDataLargeByteCount() {
+      var dump = ""
+      customDump(
+        NSData(data: .init(repeating: 0, count: 16_811)),
+        to: &dump
+      )
+      expectNoDifference(
+        dump,
+        """
+        Data(16,811 bytes)
+        """
+      )
+    }
   #endif
 
   #if !os(WASI)


### PR DESCRIPTION
Resolve issue where host settings for number formatting of thousands separator caused test failures.

Now tests comparing larger Data instances work also if your host setting differs from the original test implementation.

(This PR replaces the previous #157 which got polluted with the Android and Linux CI fix.)