### PR TITLE
Add Networking package trait gating FoundationNetworking import

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,10 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
+// Bumped from 6.0 to 6.1 to use SwiftPM package traits (added in 6.1).
+// The `Networking` trait gates the `FoundationNetworking` import + the
+// `NSURLRequest: CustomDumpRepresentable` conformance. Default is on, so
+// existing consumers see no behavior change. Consumers cross-compiling for
+// Swift Android SDK targets can disable it with `traits: []` to drop a
+// `DT_NEEDED libFoundationNetworking.so` reference (~16 MB).
 
 import PackageDescription
 
@@ -15,6 +21,10 @@ let package = Package(
       name: "CustomDump",
       targets: ["CustomDump"]
     )
+  ],
+  traits: [
+    "Networking",
+    .default(enabledTraits: ["Networking"]),
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2")

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,12 @@
 // swift-tools-version: 6.1
 // Bumped from 6.0 to 6.1 to use SwiftPM package traits (added in 6.1).
-// The `Networking` trait gates the `FoundationNetworking` import + the
-// `NSURLRequest: CustomDumpRepresentable` conformance. Default is on, so
-// existing consumers see no behavior change. Consumers cross-compiling for
-// Swift Android SDK targets can disable it with `traits: []` to drop a
-// `DT_NEEDED libFoundationNetworking.so` reference (~16 MB).
+// The `FoundationNetworking` trait gates the `FoundationNetworking` import +
+// the `NSURLRequest: CustomDumpRepresentable` and
+// `URLRequest.NetworkServiceType: CustomDumpStringConvertible` conformances.
+// Default is on, so existing consumers see no behavior change. Consumers
+// cross-compiling for the Swift Android SDK (or any other split-Foundation
+// target where `libFoundationNetworking.so` is unwanted in DT_NEEDED) can
+// disable it via `traits: []` on their `.package(...)` declaration.
 
 import PackageDescription
 
@@ -23,8 +25,8 @@ let package = Package(
     )
   ],
   traits: [
-    "Networking",
-    .default(enabledTraits: ["Networking"]),
+    "FoundationNetworking",
+    .default(enabledTraits: ["FoundationNetworking"]),
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2")

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,4 @@
 // swift-tools-version: 6.1
-// Bumped from 6.0 to 6.1 to use SwiftPM package traits (added in 6.1).
-// The `FoundationNetworking` trait gates the `FoundationNetworking` import +
-// the `NSURLRequest: CustomDumpRepresentable` and
-// `URLRequest.NetworkServiceType: CustomDumpStringConvertible` conformances.
-// Default is on, so existing consumers see no behavior change. Consumers
-// cross-compiling for the Swift Android SDK (or any other split-Foundation
-// target where `libFoundationNetworking.so` is unwanted in DT_NEEDED) can
-// disable it via `traits: []` on their `.package(...)` declaration.
 
 import PackageDescription
 

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -232,7 +232,7 @@ extension NSURLQueryItem: CustomDumpRepresentable {
   }
 }
 
-#if FoundationNetworking
+#if FoundationNetworking && canImport(FoundationNetworking)
   extension NSURLRequest: CustomDumpRepresentable {
     public var customDumpValue: Any {
       self as URLRequest
@@ -273,7 +273,7 @@ extension URL: CustomDumpStringConvertible {
   }
 }
 
-#if FoundationNetworking
+#if FoundationNetworking && canImport(FoundationNetworking)
   extension URLRequest.NetworkServiceType: CustomDumpStringConvertible {
     public var customDumpDescription: String {
       switch self { #if canImport(FoundationNetworking)

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-// `FoundationNetworking` only exists as a separate module on swift-corelibs-Foundation
-// platforms (Linux, Android, WASI). It hosts `URLRequest`, `URLSession`, etc. — types
-// that are inside Foundation itself on Apple platforms. The conformances in this file
-// that use one of those types — `NSURLRequest: CustomDumpRepresentable` and
-// `URLRequest.NetworkServiceType: CustomDumpStringConvertible` (below) — are gated on
-// the `FoundationNetworking` package trait so cross-compile consumers (Android,
-// static-Linux, WASI bridges) can opt out and drop `libFoundationNetworking.so` from
-// their DT_NEEDED.
 #if FoundationNetworking
   #if canImport(FoundationNetworking)
     import FoundationNetworking

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -2,11 +2,13 @@ import Foundation
 
 // `FoundationNetworking` only exists as a separate module on swift-corelibs-Foundation
 // platforms (Linux, Android, WASI). It hosts `URLRequest`, `URLSession`, etc. — types
-// that are inside Foundation itself on Apple platforms. The only conformance in this
-// file that uses one of those types is `NSURLRequest: CustomDumpRepresentable` (below),
-// gated on the `Networking` package trait so Android cross-compile consumers can opt
-// out and drop `libFoundationNetworking.so` from their bridge's DT_NEEDED.
-#if Networking
+// that are inside Foundation itself on Apple platforms. The conformances in this file
+// that use one of those types — `NSURLRequest: CustomDumpRepresentable` and
+// `URLRequest.NetworkServiceType: CustomDumpStringConvertible` (below) — are gated on
+// the `FoundationNetworking` package trait so cross-compile consumers (Android,
+// static-Linux, WASI bridges) can opt out and drop `libFoundationNetworking.so` from
+// their DT_NEEDED.
+#if FoundationNetworking
   #if canImport(FoundationNetworking)
     import FoundationNetworking
   #endif
@@ -241,9 +243,9 @@ extension NSURLQueryItem: CustomDumpRepresentable {
 }
 
 // `NSURLRequest` lives in `FoundationNetworking` on swift-corelibs-Foundation
-// platforms, so this conformance is gated by the `Networking` package trait
-// in addition to the existing WASI exclusion.
-#if !os(WASI) && Networking
+// platforms, so this conformance is gated by the `FoundationNetworking` package
+// trait in addition to the existing WASI exclusion.
+#if !os(WASI) && FoundationNetworking
   extension NSURLRequest: CustomDumpRepresentable {
     public var customDumpValue: Any {
       self as URLRequest
@@ -287,7 +289,7 @@ extension URL: CustomDumpStringConvertible {
 // `URLRequest.NetworkServiceType` lives in `FoundationNetworking` on
 // swift-corelibs-Foundation platforms — same trait gate as the `NSURLRequest`
 // conformance above.
-#if !os(WASI) && Networking
+#if !os(WASI) && FoundationNetworking
   extension URLRequest.NetworkServiceType: CustomDumpStringConvertible {
     public var customDumpDescription: String {
       switch self { #if canImport(FoundationNetworking)

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -1,9 +1,7 @@
 import Foundation
 
-#if FoundationNetworking
-  #if canImport(FoundationNetworking)
-    import FoundationNetworking
-  #endif
+#if FoundationNetworking && canImport(FoundationNetworking)
+  import FoundationNetworking
 #endif
 
 // NB: Xcode 13 does not include macOS 12 SDK

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -1,7 +1,15 @@
 import Foundation
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
+// `FoundationNetworking` only exists as a separate module on swift-corelibs-Foundation
+// platforms (Linux, Android, WASI). It hosts `URLRequest`, `URLSession`, etc. — types
+// that are inside Foundation itself on Apple platforms. The only conformance in this
+// file that uses one of those types is `NSURLRequest: CustomDumpRepresentable` (below),
+// gated on the `Networking` package trait so Android cross-compile consumers can opt
+// out and drop `libFoundationNetworking.so` from their bridge's DT_NEEDED.
+#if Networking
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
 #endif
 
 // NB: Xcode 13 does not include macOS 12 SDK
@@ -232,7 +240,10 @@ extension NSURLQueryItem: CustomDumpRepresentable {
   }
 }
 
-#if !os(WASI)
+// `NSURLRequest` lives in `FoundationNetworking` on swift-corelibs-Foundation
+// platforms, so this conformance is gated by the `Networking` package trait
+// in addition to the existing WASI exclusion.
+#if !os(WASI) && Networking
   extension NSURLRequest: CustomDumpRepresentable {
     public var customDumpValue: Any {
       self as URLRequest
@@ -273,7 +284,10 @@ extension URL: CustomDumpStringConvertible {
   }
 }
 
-#if !os(WASI)
+// `URLRequest.NetworkServiceType` lives in `FoundationNetworking` on
+// swift-corelibs-Foundation platforms — same trait gate as the `NSURLRequest`
+// conformance above.
+#if !os(WASI) && Networking
   extension URLRequest.NetworkServiceType: CustomDumpStringConvertible {
     public var customDumpDescription: String {
       switch self { #if canImport(FoundationNetworking)

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -242,9 +242,6 @@ extension NSURLQueryItem: CustomDumpRepresentable {
   }
 }
 
-// `NSURLRequest` lives in `FoundationNetworking` on swift-corelibs-Foundation
-// platforms, so this conformance is gated by the `FoundationNetworking` package
-// trait in addition to the existing WASI exclusion.
 #if !os(WASI) && FoundationNetworking
   extension NSURLRequest: CustomDumpRepresentable {
     public var customDumpValue: Any {
@@ -286,9 +283,6 @@ extension URL: CustomDumpStringConvertible {
   }
 }
 
-// `URLRequest.NetworkServiceType` lives in `FoundationNetworking` on
-// swift-corelibs-Foundation platforms — same trait gate as the `NSURLRequest`
-// conformance above.
 #if !os(WASI) && FoundationNetworking
   extension URLRequest.NetworkServiceType: CustomDumpStringConvertible {
     public var customDumpDescription: String {

--- a/Sources/CustomDump/Conformances/Foundation.swift
+++ b/Sources/CustomDump/Conformances/Foundation.swift
@@ -232,7 +232,7 @@ extension NSURLQueryItem: CustomDumpRepresentable {
   }
 }
 
-#if !os(WASI) && FoundationNetworking
+#if FoundationNetworking
   extension NSURLRequest: CustomDumpRepresentable {
     public var customDumpValue: Any {
       self as URLRequest
@@ -273,7 +273,7 @@ extension URL: CustomDumpStringConvertible {
   }
 }
 
-#if !os(WASI) && FoundationNetworking
+#if FoundationNetworking
   extension URLRequest.NetworkServiceType: CustomDumpStringConvertible {
     public var customDumpDescription: String {
       switch self { #if canImport(FoundationNetworking)


### PR DESCRIPTION
Adds a `Networking` package trait (default-on, mirrors swift-dependencies PR #406) gating the `import FoundationNetworking` and the two FoundationNetworking-typed CustomDump conformances (`NSURLRequest: CustomDumpRepresentable` and `URLRequest.NetworkServiceType: CustomDumpStringConvertible`). Default-on means no behavior change for Apple/Linux consumers. Consumers cross-compiling for Android can declare `traits: []` to skip those conformances, dropping `libFoundationNetworking.so` (~16 MB) from their bridge's `DT_NEEDED`. Bumps swift-tools-version 6.0→6.1 for the `traits:` API.