### PR TITLE
Fix incosistency in printing of "object" identity

### DIFF
--- a/Sources/CustomDump/Diff.swift
+++ b/Sources/CustomDump/Diff.swift
@@ -365,24 +365,33 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
         let subjectType =
           customType.map { typeName($0) }
           ?? typeName(lhsMirror.subjectType)
-        var occurrence = tracker.occurrencePerType[subjectType, default: 1] {
+        var occurrence = tracker.occurrencePerType[subjectType, default: 0] {
           didSet { tracker.occurrencePerType[subjectType] = occurrence }
         }
-        var id: UInt {
+        var id: String {
           let id = tracker.idPerItem[lhsItem, default: occurrence]
           tracker.idPerItem[lhsItem] = id
-          return id
+          return id > 0 ? "#\(id)" : ""
+        }
+        func label(_ name: String?) -> String? {
+          switch (name, id.isEmpty) {
+          case let (name?, false): return "\(name): \(id)"
+          case let (name?, true): return "\(name):"
+          case (nil, false): return id
+          case (nil, true): return nil
+          }
         }
         if tracker.visitedItems.contains(lhsItem) {
           print(
-            "\(lhsName.map { "\($0): " } ?? "")#\(id) \(subjectType)(↩︎)\(separator)"
+            "\(lhsName.map { "\($0): " } ?? "")\(id.isEmpty ? "" : "\(id) ")\(subjectType)(↩︎)\(separator)"
               .indenting(by: indent)
               .indenting(with: format.both + " "),
             terminator: "",
             to: &out
           )
         } else {
-          let id = id
+          let lhsLabel = label(lhsName)
+          let rhsLabel = label(rhsName)
           tracker.visitedItems.insert(lhsItem)
           occurrence += 1
           diffChildren(
@@ -390,8 +399,8 @@ public func diff<T>(_ lhs: T, _ rhs: T, format: DiffFormat = .default) -> String
             rhs: rhs,
             lhsMirror,
             rhsMirror,
-            lhsName: "\(lhsName.map { "\($0): " } ?? "")#\(id)",
-            rhsName: "\(rhsName.map { "\($0): " } ?? "")#\(id)",
+            lhsName: lhsLabel,
+            rhsName: rhsLabel,
             nameSuffix: "",
             prefix: "\(subjectType)(",
             suffix: ")",

--- a/Sources/CustomDump/Dump.swift
+++ b/Sources/CustomDump/Dump.swift
@@ -196,7 +196,7 @@ func _customDump<T, TargetStream>(
       let subjectType =
         customType.map { typeName($0) }
         ?? typeName(valueMirror.subjectType)
-      var occurrence = tracker.occurrencePerType[subjectType, default: 1] {
+      var occurrence = tracker.occurrencePerType[subjectType, default: 0] {
         didSet { tracker.occurrencePerType[subjectType] = occurrence }
       }
 

--- a/Tests/CustomDumpTests/DiffTests.swift
+++ b/Tests/CustomDumpTests/DiffTests.swift
@@ -1231,7 +1231,7 @@ final class DiffTests: XCTestCase {
     expectNoDifference(
       diff(obj, obj),
       """
-        #1 User(
+        User(
           id: 1,
       -   name: "Blob"
       +   name: "Blob, Jr"
@@ -1242,11 +1242,11 @@ final class DiffTests: XCTestCase {
     expectNoDifference(
       diff(Shared(), Shared()),
       """
-      - #1 User(
+      - User(
       -   id: 1,
       -   name: "Blob, Jr"
       - )
-      + #2 User(
+      + #1 User(
       +   id: 1,
       +   name: "Blob, Jr"
       + )
@@ -1257,14 +1257,14 @@ final class DiffTests: XCTestCase {
       diff([obj, obj, obj], [obj, obj, Shared()]),
       """
         [
-          [0]: #1 User(
+          [0]: User(
             id: 1,
       -     name: "Blob"
       +     name: "Blob, Jr"
           ),
-          [1]: #1 User(↩︎),
-      -   [2]: #1 User(↩︎)
-      +   [2]: #2 User(
+          [1]: User(↩︎),
+      -   [2]: User(↩︎)
+      +   [2]: #1 User(
       +     id: 1,
       +     name: "Blob, Jr"
       +   )
@@ -1283,8 +1283,8 @@ final class DiffTests: XCTestCase {
       diff(stats, stats),
       """
         DiffTests.State(
-      -   stats: #1 DiffTests.Stats(count: 0)
-      +   stats: #1 DiffTests.Stats(count: 1)
+      -   stats: DiffTests.Stats(count: 0)
+      +   stats: DiffTests.Stats(count: 1)
         )
       """
     )
@@ -1305,8 +1305,8 @@ final class DiffTests: XCTestCase {
       after: SharedNodeValue(name: "Root!", child: nil)
     )
     let child = SharedNode(
-      before: SharedNodeValue(name: "Child", child: root),
-      after: SharedNodeValue(name: "Child!", child: root)
+      before: SharedNodeValue(name: "Child", child: nil),
+      after: SharedNodeValue(name: "Child!", child: nil)
     )
     root.beforeValue.child = child
     root.afterValue.child = child
@@ -1314,13 +1314,13 @@ final class DiffTests: XCTestCase {
     expectNoDifference(
       diff(root, root),
       """
-        #1 SharedNodeValue(
+        SharedNodeValue(
       -   name: "Root",
       +   name: "Root!",
-          child: #2 SharedNodeValue(
+          child: #1 SharedNodeValue(
       -     name: "Child",
       +     name: "Child!",
-            child: #1 SharedNodeValue(↩︎)
+            child: nil
           )
         )
       """
@@ -1349,8 +1349,8 @@ final class DiffTests: XCTestCase {
     let difference = diff(lhsRoot, rhsRoot)
 
     XCTAssertNotNil(difference)
-    XCTAssertTrue(difference?.contains(#"#1 SnapshotNode(↩︎)"#) == true)
-    XCTAssertTrue(difference?.contains(#"#2 SnapshotNode("#) == true)
+    XCTAssertTrue(difference?.contains(#"SnapshotNode(↩︎)"#) == true)
+    XCTAssertTrue(difference?.contains(#"#1 SnapshotNode("#) == true)
   }
 
   func testDiffableObjectCollectionIdentityAcrossGraphs() {
@@ -1390,7 +1390,7 @@ final class DiffTests: XCTestCase {
     expectNoDifference(
       diff(lhs, rhs),
       """
-        #1 SingleValueNode(
+        SingleValueNode(
           numbers: [
       +     [0]: 4
           ]

--- a/Tests/CustomDumpTests/DumpTests.swift
+++ b/Tests/CustomDumpTests/DumpTests.swift
@@ -1335,12 +1335,12 @@ final class DumpTests: XCTestCase {
       """
       DumpTests.DiffableObjectsParent(
         objs1: DumpTests.DiffableObjects(
-          obj1: #1 DumpTests.Login(email: "admin@pointfree.co"),
-          obj2: #1 DumpTests.Login(↩︎)
+          obj1: DumpTests.Login(email: "admin@pointfree.co"),
+          obj2: DumpTests.Login(↩︎)
         ),
         objs2: DumpTests.DiffableObjects(
-          obj1: #2 DumpTests.Login(email: "admin@pointfree.co"),
-          obj2: #2 DumpTests.Login(↩︎)
+          obj1: #1 DumpTests.Login(email: "admin@pointfree.co"),
+          obj2: #1 DumpTests.Login(↩︎)
         )
       )
       """
@@ -1356,12 +1356,12 @@ final class DumpTests: XCTestCase {
       """
       DumpTests.DiffableObjectsParent(
         objs1: DumpTests.DiffableObjects(
-          obj1: #1 DumpTests.Login(email: "admin@pointfree.co"),
-          obj2: #2 DumpTests.Login(email: "admin@pointfree.co")
+          obj1: DumpTests.Login(email: "admin@pointfree.co"),
+          obj2: #1 DumpTests.Login(email: "admin@pointfree.co")
         ),
         objs2: DumpTests.DiffableObjects(
-          obj1: #2 DumpTests.Login(↩︎),
-          obj2: #1 DumpTests.Login(↩︎)
+          obj1: #1 DumpTests.Login(↩︎),
+          obj2: DumpTests.Login(↩︎)
         )
       )
       """
@@ -1399,12 +1399,12 @@ final class DumpTests: XCTestCase {
       """
       DumpTests.DiffableObjectsParent(
         objs1: DumpTests.DiffableObjects(
-          obj1: #1 "after",
-          obj2: #1 String(↩︎)
+          obj1: "after",
+          obj2: String(↩︎)
         ),
         objs2: DumpTests.DiffableObjects(
-          obj1: #2 "after",
-          obj2: #2 String(↩︎)
+          obj1: #1 "after",
+          obj2: #1 String(↩︎)
         )
       )
       """


### PR DESCRIPTION
In a dump, a reference tracker is used to annotate different objects, _e.g._ `#1 Object(...)` vs. `#2 Object(...)`, and these numbers are used to collapse duplicates as well as cut off infinite self-referential trees.

We are currently inconsistent in _when_ we add these number identifiers, though. With plain objects we only add them after we hit 2 values of the same type, but with "custom diff objects" (types that tie their identity to some other object, like the `@Shared` type) _always_ prepend this number.

This PR aligns the behavior by suppressing the first `#` in custom diff objects, as well.