### PR TITLE
Bump to IssueReporting 2.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b8074a296a58bd0e3a7e2a4bec81624e2dfa3114663fceb0c68d7abb02c67c32",
+  "originHash" : "d232c85b5a3407a15049fedcc4685772d0cc74496d09143fe9bc202e53075c49",
   "pins" : [
     {
-      "identity" : "xctest-dynamic-overlay",
+      "identity" : "swift-issue-reporting",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
       "state" : {
-        "branch" : "xcode-26-fix",
-        "revision" : "8f50fd37682807c9fa193340dc477f3b8c76291b"
+        "revision" : "71c7c9a761d1ca6ed4ccb6ced040fe1c1a39e8e7",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6f68f2fe1f6c6b8186c49a7e0648a92258927fa22b926440c59a5bd7ee1a76be",
+  "originHash" : "b8074a296a58bd0e3a7e2a4bec81624e2dfa3114663fceb0c68d7abb02c67c32",
   "pins" : [
     {
-      "identity" : "swift-issue-reporting",
+      "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-issue-reporting",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "d6adc8bc81e8ba37d3ecd094b78450853738a89f",
-        "version" : "2.0.0"
+        "branch" : "xcode-26-fix",
+        "revision" : "8f50fd37682807c9fa193340dc477f3b8c76291b"
       }
     }
   ],

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.4
+// swift-tools-version: 6.1
 
 import PackageDescription
 
@@ -21,20 +21,20 @@ let package = Package(
     .default(enabledTraits: ["FoundationNetworking"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-issue-reporting", from: "2.1.0")
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", branch: "xcode-26-fix")
   ],
   targets: [
     .target(
       name: "CustomDump",
       dependencies: [
-        .product(name: "IssueReporting", package: "swift-issue-reporting"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
       name: "CustomDumpTests",
       dependencies: [
         "CustomDump",
-        .product(name: "IssueReportingTestSupport", package: "swift-issue-reporting"),
+        .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
       ]
     ),
   ]


### PR DESCRIPTION
This PR builds on #169 to show what we need to do in all of our repos to eventually get to IssueReporting 2.x. Essentially we split the manifests so that Swift <6.4 depends on xctest-dynamic-overlay and Swift >=6.4 depends on swift-issue-reporting.