### PR TITLE
Add Privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
       name: "CustomDump",
       dependencies: [
         .product(name: "IssueReporting", package: "swift-issue-reporting")
-      ]
+      ],
+      resources: [.process("PrivacyInfo.xcprivacy")]
     ),
     .testTarget(
       name: "CustomDumpTests",

--- a/Sources/CustomDump/PrivacyInfo.xcprivacy
+++ b/Sources/CustomDump/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
This package handles objects that may contain user data, but never calls any API that retrieves this data. It also doesn't keep a reference to any of the input objects.

For this reason, all fields in the manifest can be empty.